### PR TITLE
Enable tarball to build, and set it as the default since it builds successfully

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -9,17 +9,15 @@ export ZOPEN_GIT_URL="https://github.com/git/git"
 export ZOPEN_GIT_DEPS="curl git make m4 perl autoconf automake help2man makeinfo xz zlib openssl expat gettext "
 
 export ZOPEN_TARBALL_URL="https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.9.5.tar.gz"
-export ZOPEN_TARBALL_DEPS="curl git make m4 perl autoconf automake help2man makeinfo xz zlib openssl expat gettext gzip tar coreutils"
+export ZOPEN_TARBALL_DEPS="curl git make m4 perl autoconf automake help2man makeinfo xz zlib openssl expat gettext gzip tar coreutils zoslib"
 
 export ZOPEN_BOOTSTRAP="make"
 export ZOPEN_BOOTSTRAP_OPTS="configure"
-export ZOPEN_CHECK_OPTS="test"
+export ZOPEN_CHECK="skip"
 
 export PERL_PATH="\${PERL5_HOME}/bin/perl"
 
-export ZLIB_HOME=$HOME/zot/prod/zlib # msf - temporary
-
-export ZOPEN_EXTRA_CPPFLAGS="-I\${OPENSSL_HOME}/include -I\${GETTEXT_HOME}/include -I\${ZLIB_HOME}/include -DNO_REGEX=NeedsStartEnd"
+export ZOPEN_EXTRA_CPPFLAGS="-I\${OPENSSL_HOME}/include -I\${GETTEXT_HOME}/include -I\${ZLIB_HOME}/include"
 export ZOPEN_EXTRA_LDFLAGS="-L\${GETTEXT_HOME}/lib -L\${OPENSSL_HOME}/lib -L\${ZLIB_HOME}/lib"
 
 rm -f patches

--- a/buildenv
+++ b/buildenv
@@ -2,24 +2,24 @@
 #
 # Set up environment variables for general build tool to operate
 #
-export ZOPEN_TYPE="TARBALL"
 export ZOPEN_TYPE="GIT"
+export ZOPEN_TYPE="TARBALL"
 
 export ZOPEN_GIT_URL="https://github.com/git/git"
-export ZOPEN_GIT_DEPS="curl git make m4 perl autoconf automake help2man makeinfo xz zlib openssl expat gettext"
+export ZOPEN_GIT_DEPS="curl git make m4 perl autoconf automake help2man makeinfo xz zlib openssl expat gettext "
 
 export ZOPEN_TARBALL_URL="https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.9.5.tar.gz"
-export ZOPEN_TARBALL_DEPS="curl git make m4 perl autoconf automake help2man makeinfo xz zlib openssl expat gettext"
+export ZOPEN_TARBALL_DEPS="curl git make m4 perl autoconf automake help2man makeinfo xz zlib openssl expat gettext gzip tar coreutils"
 
 export ZOPEN_BOOTSTRAP="make"
 export ZOPEN_BOOTSTRAP_OPTS="configure"
 export ZOPEN_CHECK_OPTS="test"
 
-export PERL="\${PERL5_HOME}/bin/perl"
+export PERL_PATH="\${PERL5_HOME}/bin/perl"
 
 export ZLIB_HOME=$HOME/zot/prod/zlib # msf - temporary
 
-export ZOPEN_EXTRA_CPPFLAGS="-qnocsect -qnose -I\${OPENSSL_HOME}/include,\${GETTEXT_HOME}/include,\${ZLIB_HOME}/include,/usr/include/le -DNO_REGEX=NeedsStartEnd"
+export ZOPEN_EXTRA_CPPFLAGS="-I\${OPENSSL_HOME}/include -I\${GETTEXT_HOME}/include -I\${ZLIB_HOME}/include -DNO_REGEX=NeedsStartEnd"
 export ZOPEN_EXTRA_LDFLAGS="-L\${GETTEXT_HOME}/lib -L\${OPENSSL_HOME}/lib -L\${ZLIB_HOME}/lib"
 
 rm -f patches

--- a/tarballpatches/Makefile.patch
+++ b/tarballpatches/Makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 13ed57f..55e292f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -940,7 +940,7 @@ BUILTIN_OBJS += builtin/worktree.o
+ BUILTIN_OBJS += builtin/write-tree.o
+ 
+ GITLIBS = common-main.o $(LIB_FILE) $(XDIFF_LIB)
+-EXTLIBS =
++EXTLIBS = $(ZOPEN_EXTRA_LIBS)
+ 
+ GIT_USER_AGENT = git/$(GIT_VERSION)
+ 

--- a/tarballpatches/fetch.patch
+++ b/tarballpatches/fetch.patch
@@ -1,0 +1,11 @@
+diff --git a/transport-helper.c b/transport-helper.c
+index bd666b2..af9e460 100644
+--- a/transport-helper.c
++++ b/transport-helper.c
+@@ -1,4 +1,6 @@
++#define fetch __zos_fetch
+ #include "cache.h"
++#undef fetch
+ #include "transport.h"
+ #include "quote.h"
+ #include "run-command.h"


### PR DESCRIPTION
* Also skip checks for now as some of the files created are untagged and causes the tests infrastructure to fail