### PR TITLE
Add pager.c fix + avoid curl-config because it can have hardcoded paths

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -18,7 +18,10 @@ export ZOPEN_EXTRA_CONFIGURE_OPTS="--with-zlib=\${ZLIB_HOME} --with-curl=\${CURL
 
 export ZOPEN_EXTRA_CPPFLAGS="-I\${OPENSSL_HOME}/include -I\${GETTEXT_HOME}/include -I\${ZLIB_HOME}/include -I\${NCURSES_HOME}/include -I\${ZOPEN_ROOT}/patches/include -I\${CURL_HOME}/include -I\${EXPAT_HOME}/include"
 export ZOPEN_EXTRA_LDFLAGS="-L\${GETTEXT_HOME}/lib -L\${OPENSSL_HOME}/lib -L\${ZLIB_HOME}/lib -L\${NCURSES_HOME}/lib -L\${CURL_HOME}/lib -L\${EXPAT_HOME}/lib"
-export ZOPEN_EXTRA_LIBS="$ZOPEN_EXTRA_LIBS -lssl -lcrypto -lz -lcurl"
+export ZOPEN_EXTRA_LIBS="${ZOPEN_EXTRA_LIBS} -lz -lcurl -lssl -lcrypto"
+export CURL_LDFLAGS="-lcurl"
+export CURL_CFLAGS="-I\${CURL_HOME}/include"
+export CURL_CONFIG="no"
 
 rm -f patches
 if [ "${ZOPEN_TYPE}" = "TARBALL" ]; then

--- a/tarballpatches/pager.c.patch
+++ b/tarballpatches/pager.c.patch
@@ -1,0 +1,17 @@
+diff --git a/pager.c b/pager.c
+index b66bbff..f0e90fd 100644
+--- a/pager.c
++++ b/pager.c
+@@ -66,7 +66,12 @@ const char *git_pager(int stdout_is_tty)
+ 	if (!*pager || !strcmp(pager, "cat"))
+ 		pager = NULL;
+ 
++#ifdef __MVS__
++  // The location pointed to by pager gets overwritten by z/OS LE, duplicate it as a workaround
++	return xstrdup(pager);
++#else
+ 	return pager;
++#endif
+ }
+ 
+ static void setup_pager_env(struct strvec *env)


### PR DESCRIPTION
* Fixes https://github.com/ZOSOpenTools/gitport/issues/19
* Also curl-config has hardcoded paths from where curl was built from, and if we leverage the curl from Jenkins, it'll fail so avoiding curl-config.