### PR TITLE
Add tagging support for working-tree-encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,30 +3,34 @@ To use Git on z/OS, source the .env file as follows:
 `. ./.env`
 
 ## Encoding considerations
-Git on z/OS leverages the git .gitattributes support to enable support for various encodings, documented [here](https://git-scm.com/docs/gitattributes). 
-.gitattributes can be specified globally, or repositories to determine the encoding of working tree files.
+Git on z/OS leverages Git's `.gitattributes` support to enable support for various encodings, documented [here](https://git-scm.com/docs/gitattributes). 
+`.gitattributes` can be specified globally, or locally in repositories to determine the encoding of working tree files.
 
-Specifically, the `working-tree-encoding` attribute can be used to determine the working tree encoding. For example,
-to convert all files from the internal UTF-8 encoding to IBM-1047, you can specify the following working-tree-encoding:
+### Working-tree-encoding
+The `working-tree-encoding` attribute can be used to determine the working tree encoding. For example,
+to convert all files from Git's internal UTF-8 encoding to IBM-1047, you can specify the following working-tree-encoding:
 ```
 * text working-tree-encoding=IBM-1047
 ```
-Git on z/OS will also tag files as ibm-1047 on checkout. 
+This will also result in Git on z/OS tagging all files as ibm-1047 on checkout. 
 
 If no encoding is specified, the default UTF-8 encoding is used and all files are tagged as ISO8859-1. 
 
-To add specify binary encoding, you can use the binary attribute as follows:
+### Binary files
+To specify a binary encoding, you can use the binary attribute as follows:
 ```
 *.png binary
 ```
 This will tag all `*.png` files as binary.
 
+### Multiple encodings
 You can specify multiple working-tree-encoding attributes, where the later attributes overrides the initial attributes in case of an overlap.
 ```
 * text working-tree-encoding=IBM-1047
 *.png binary
 ```
 
+### Gotchas
 When adding files, you need to make sure that the z/OS file tag matches the working-tree-encoding. Otherwise, you may encounter an error.
 
 NOTE: Git on z/OS does not currently support adding `untagged` files.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ When adding files, you need to make sure that the z/OS file tag matches the work
 
 NOTE: Git on z/OS does not currently support adding `untagged` files.
 
-### Comparison Rocket Software's Git
-Rocket Software implemented zos-working-tree-encoding, including it's synonym working-tree-encoding. Git on z/OS does not support zos-working-tree-encoding.
-Additionally, Rocket software implemented zos-working-tree-encoding from scratch, while Git on z/OS leverages the Git's official working-tree-encoding support.
+### Comparison to Rocket Software's Git
+Rocket Software implemented `zos-working-tree-encoding`, including it's synonym `working-tree-encoding`. Git on z/OS does not support zos-working-tree-encoding.
+Furthermore, Rocket Software implemented zos-working-tree-encoding from scratch, while Git on z/OS leverages the Git's official working-tree-encoding support.
 
-Binary files are also treated differently. With Rocket's Git, zos-working-tree-encoding=BINARY must be specified to ensure a file is tagged as binary. 
+Binary files are also handled differently. With Rocket's Git, `zos-working-tree-encoding=BINARY` must be specified to ensure a file is tagged as binary. 
 Git on z/OS leverages the `binary` keyword, which is officially supported by Git.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This will result in Git on z/OS tagging all files as IBM-1047 on checkout.
 
 If no encoding is specified, the default UTF-8 encoding is used and all files are tagged as ISO8859-1. 
 
+To find out all of the supported encodings, run `iconv -l`.
+
 ### Binary files
 To specify a binary encoding, you can use the binary attribute as follows:
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Git on z/OS
+To use Git on z/OS, source the .env file as follows:
+`. ./.env`
+
+## Encoding considerations
+Git on z/OS leverages the git .gitattributes support to enable support for various encodings, documented [here](https://git-scm.com/docs/gitattributes). 
+.gitattributes can be specified globally, or repositories to determine the encoding of working tree files.
+
+Specifically, the `working-tree-encoding` attribute can be used to determine the working tree encoding. For example,
+to convert all files from the internal UTF-8 encoding to IBM-1047, you can specify the following working-tree-encoding:
+```
+* text working-tree-encoding=IBM-1047
+```
+Git on z/OS will also tag files as ibm-1047 on checkout. 
+
+If no encoding is specified, the default UTF-8 encoding is used and all files are tagged as ISO8859-1. 
+
+To add specify binary encoding, you can use the binary attribute as follows:
+```
+*.png binary
+```
+This will tag all `*.png` files as binary.
+
+You can specify multiple working-tree-encoding attributes, where the later attributes overrides the initial attributes in case of an overlap.
+```
+* text working-tree-encoding=IBM-1047
+*.png binary
+```
+
+When adding files, you need to make sure that the z/OS file tag matches the working-tree-encoding. Otherwise, you may encounter an error.
+
+NOTE: Git on z/OS does not currently support adding `untagged` files.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Git on z/OS leverages Git's `.gitattributes` support to enable support for vario
 
 ### Working-tree-encoding
 The `working-tree-encoding` attribute can be used to determine the working tree encoding. For example,
-to convert all files from Git's internal UTF-8 encoding to IBM-1047, you can specify the following working-tree-encoding:
+to convert all files from Git's internal UTF-8 encoding to IBM-1047, you can specify the following working-tree-encoding in your .gitattributes file:
 ```
 * text working-tree-encoding=IBM-1047
 ```
-This will also result in Git on z/OS tagging all files as ibm-1047 on checkout. 
+This will result in Git on z/OS tagging all files as IBM-1047 on checkout. 
 
 If no encoding is specified, the default UTF-8 encoding is used and all files are tagged as ISO8859-1. 
 
@@ -34,3 +34,10 @@ You can specify multiple working-tree-encoding attributes, where the later attri
 When adding files, you need to make sure that the z/OS file tag matches the working-tree-encoding. Otherwise, you may encounter an error.
 
 NOTE: Git on z/OS does not currently support adding `untagged` files.
+
+### Comparison Rocket Software's Git
+Rocket Software implemented zos-working-tree-encoding, including it's synonym working-tree-encoding. Git on z/OS does not support zos-working-tree-encoding.
+Additionally, Rocket software implemented zos-working-tree-encoding from scratch, while Git on z/OS leverages the Git's official working-tree-encoding support.
+
+Binary files are also treated differently. With Rocket's Git, zos-working-tree-encoding=BINARY must be specified to ensure a file is tagged as binary. 
+Git on z/OS leverages the `binary` keyword, which is officially supported by Git.

--- a/tarballpatches/combine-diff.c.patch
+++ b/tarballpatches/combine-diff.c.patch
@@ -1,0 +1,15 @@
+diff --git a/combine-diff.c b/combine-diff.c
+index b0ece95..9e5ed73 100644
+--- a/combine-diff.c
++++ b/combine-diff.c
+@@ -1077,6 +1077,10 @@ static void show_patch_diff(struct combine_diff_path *elem, int num_parent,
+ 			ssize_t done;
+ 			int is_file, i;
+ 
++#ifdef __MVS__
++      __disableautocvt(fd);      
++#endif
++
+ 			elem->mode = canon_mode(st.st_mode);
+ 			/* if symlinks don't work, assume symlink if all parents
+ 			 * are symlinks

--- a/tarballpatches/copy.c.patch
+++ b/tarballpatches/copy.c.patch
@@ -1,0 +1,14 @@
+diff --git a/copy.c b/copy.c
+index 4de6a11..c5584d4 100644
+--- a/copy.c
++++ b/copy.c
+@@ -12,6 +12,9 @@ int copy_fd(int ifd, int ofd)
+ 		if (write_in_full(ofd, buffer, len) < 0)
+ 			return COPY_WRITE_ERROR;
+ 	}
++#ifdef __MVS__
++  __copyfdccsid(ifd, ofd);
++#endif
+ 	return 0;
+ }
+ 

--- a/tarballpatches/diff.c.patch
+++ b/tarballpatches/diff.c.patch
@@ -1,0 +1,30 @@
+diff --git a/diff.c b/diff.c
+index 648f671..a988d29 100644
+--- a/diff.c
++++ b/diff.c
+@@ -4001,6 +4001,7 @@ int diff_populate_filespec(struct repository *r,
+ 	int check_binary = options ? options->check_binary : 0;
+ 	int err = 0;
+ 	int conv_flags = global_conv_flags_eol;
++  int autocvtToASCII;
+ 	/*
+ 	 * demote FAIL to WARN to allow inspecting the situation
+ 	 * instead of refusing.
+@@ -4073,9 +4074,17 @@ int diff_populate_filespec(struct repository *r,
+ 			s->is_binary = 1;
+ 			return 0;
+ 		}
++#ifdef __MVS__
++    validate_codeset(r->index, s->path, &autocvtToASCII);
++#endif
+ 		fd = open(s->path, O_RDONLY);
+ 		if (fd < 0)
+ 			goto err_empty;
++
++#ifdef __MVS__
++    if (!autocvtToASCII)
++      __disableautocvt(fd);
++#endif
+ 		s->data = xmmap(NULL, s->size, PROT_READ, MAP_PRIVATE, fd, 0);
+ 		close(fd);
+ 		s->should_munmap = 1;

--- a/tarballpatches/entry.c.patch
+++ b/tarballpatches/entry.c.patch
@@ -1,0 +1,51 @@
+diff --git a/entry.c b/entry.c
+index 616e4f0..3fdca74 100644
+--- a/entry.c
++++ b/entry.c
+@@ -119,6 +119,24 @@ int fstat_checkout_output(int fd, const struct checkout *state, struct stat *st)
+ 	return 0;
+ }
+ 
++#ifdef __MVS__
++void tag_file_as_working_tree_encoding(struct index_state *istate, char* path, int fd) {
++	struct conv_attrs ca;
++	convert_attrs(istate, &ca, path);
++  if (ca.attr_action != CRLF_BINARY) {
++    if (ca.working_tree_encoding)
++      __chgfdcodeset(fd, ca.working_tree_encoding); 
++    else
++      __setfdtext(fd);
++  }
++  else {
++    __setfdbinary(fd);
++  }
++
++  __disableautocvt(fd);
++}
++#endif
++
+ static int streaming_write_entry(const struct cache_entry *ce, char *path,
+ 				 struct stream_filter *filter,
+ 				 const struct checkout *state, int to_tempfile,
+@@ -131,6 +149,10 @@ static int streaming_write_entry(const struct cache_entry *ce, char *path,
+ 	if (fd < 0)
+ 		return -1;
+ 
++#ifdef __MVS__
++  tag_file_as_working_tree_encoding(state->istate, path, fd);
++#endif
++
+ 	result |= stream_blob_to_fd(fd, &ce->oid, filter, 1);
+ 	*fstat_done = fstat_checkout_output(fd, state, statbuf);
+ 	result |= close(fd);
+@@ -367,6 +389,10 @@ static int write_entry(struct cache_entry *ce, char *path, struct conv_attrs *ca
+ 			return error_errno("unable to create file %s", path);
+ 		}
+ 
++#ifdef __MVS__
++    tag_file_as_working_tree_encoding(state->istate, path, fd);
++#endif
++
+ 		wrote = write_in_full(fd, new_blob, size);
+ 		if (!to_tempfile)
+ 			fstat_done = fstat_checkout_output(fd, state, &st);

--- a/tarballpatches/object-file.c.patch
+++ b/tarballpatches/object-file.c.patch
@@ -1,5 +1,5 @@
 diff --git a/object-file.c b/object-file.c
-index 5b270f0..131f2e5 100644
+index 5b270f0..1b8626e 100644
 --- a/object-file.c
 +++ b/object-file.c
 @@ -8,6 +8,7 @@
@@ -21,7 +21,7 @@ index 5b270f0..131f2e5 100644
  /* The maximum size for an object header. */
  #define MAX_HEADER_LEN 32
  
-@@ -2499,18 +2504,84 @@ int index_fd(struct index_state *istate, struct object_id *oid,
+@@ -2499,18 +2504,87 @@ int index_fd(struct index_state *istate, struct object_id *oid,
  	return ret;
  }
  
@@ -63,6 +63,9 @@ index 5b270f0..131f2e5 100644
 +  if (attr_ccsid != file_ccsid) {
 +    if (file_ccsid == 1047 && attr_ccsid == 819) {
 +      *autoconvertToASCII = 1;
++      return;
++    }
++    if (file_ccsid == 819 && attr_ccsid == 1208) {
 +      return;
 +    }
 +    char attr_csname[_XOPEN_PATH_MAX] = {0};

--- a/tarballpatches/object-file.c.patch
+++ b/tarballpatches/object-file.c.patch
@@ -1,0 +1,108 @@
+diff --git a/object-file.c b/object-file.c
+index 5b270f0..131f2e5 100644
+--- a/object-file.c
++++ b/object-file.c
+@@ -8,6 +8,7 @@
+  */
+ #include "cache.h"
+ #include "config.h"
++#include "convert.h"
+ #include "string-list.h"
+ #include "lockfile.h"
+ #include "delta.h"
+@@ -34,6 +35,10 @@
+ #include "promisor-remote.h"
+ #include "submodule.h"
+ 
++#ifdef __MVS__
++#include <_Ccsid.h>
++#endif
++
+ /* The maximum size for an object header. */
+ #define MAX_HEADER_LEN 32
+ 
+@@ -2499,18 +2504,84 @@ int index_fd(struct index_state *istate, struct object_id *oid,
+ 	return ret;
+ }
+ 
++#ifdef __MVS__
++int validate_codeset(struct index_state *istate, const char *path, int* autoconvertToASCII) {
++	struct conv_attrs ca;
++  struct stat st;
++  unsigned short attr_ccsid;
++  unsigned short file_ccsid;
++  *autoconvertToASCII = 0;
++	convert_attrs(istate, &ca, path);
++#if DEBUG
++    fprintf(stderr, "Processing %s\n", path);
++#endif
++  if (ca.attr_action == CRLF_BINARY) {
++#if DEBUG
++    fprintf(stderr, "Is binary");
++#endif
++    attr_ccsid = FT_BINARY;
++  }
++  else if (ca.working_tree_encoding) {
++#if DEBUG
++    fprintf(stderr, "Working-tree-encoding %s\n", ca.working_tree_encoding);
++#endif
++    attr_ccsid = __toCcsid(ca.working_tree_encoding);
++  }
++  else
++    attr_ccsid = 819;
++
++  if (stat(path, &st) < 0)
++    return;
++
++  file_ccsid = st.st_tag.ft_ccsid;
++
++  if (file_ccsid == FT_UNTAGGED) {
++    die("File %s is untagged, set the correct file tag (using the chtag command).", path);
++  }
++
++  if (attr_ccsid != file_ccsid) {
++    if (file_ccsid == 1047 && attr_ccsid == 819) {
++      *autoconvertToASCII = 1;
++      return;
++    }
++    char attr_csname[_XOPEN_PATH_MAX] = {0};
++    char file_csname[_XOPEN_PATH_MAX] = {0};
++    if (attr_ccsid != FT_BINARY) {
++      __toCSName(attr_ccsid, attr_csname);
++    } else { 
++      snprintf(attr_csname, _XOPEN_PATH_MAX, "%s", "binary");
++    }
++    if (file_ccsid != FT_BINARY) {
++      __toCSName(file_ccsid, file_csname);
++    } else { 
++      snprintf(file_csname, _XOPEN_PATH_MAX, "%s", "binary");
++    }
++    die("%s added file: file tag (%s) does not match working-tree-encoding (%s)", path, file_csname, attr_csname); 
++  }
++}
++#endif
++
+ int index_path(struct index_state *istate, struct object_id *oid,
+ 	       const char *path, struct stat *st, unsigned flags)
+ {
+ 	int fd;
+ 	struct strbuf sb = STRBUF_INIT;
+ 	int rc = 0;
++  struct conv_attrs ca;
++  int autocvtToASCII;
+ 
+ 	switch (st->st_mode & S_IFMT) {
+ 	case S_IFREG:
++#ifdef __MVS__
++    validate_codeset(istate, path, &autocvtToASCII);
++#endif
+ 		fd = open(path, O_RDONLY);
+ 		if (fd < 0)
+ 			return error_errno("open(\"%s\")", path);
++#ifdef __MVS__
++    if (!autocvtToASCII)
++      __disableautocvt(fd);
++#endif
+ 		if (index_fd(istate, oid, fd, st, OBJ_BLOB, path, flags) < 0)
+ 			return error(_("%s: failed to insert into database"),
+ 				     path);

--- a/tarballpatches/read-cache.c.patch
+++ b/tarballpatches/read-cache.c.patch
@@ -1,0 +1,14 @@
+diff --git a/read-cache.c b/read-cache.c
+index b09128b..7bc57dd 100644
+--- a/read-cache.c
++++ b/read-cache.c
+@@ -244,6 +244,9 @@ static int ce_compare_data(struct index_state *istate,
+ 	int fd = git_open_cloexec(ce->name, O_RDONLY);
+ 
+ 	if (fd >= 0) {
++#ifdef __MVS__
++    __disableautocvt(fd);
++#endif
+ 		struct object_id oid;
+ 		if (!index_fd(istate, &oid, fd, st, OBJ_BLOB, ce->name, 0))
+ 			match = !oideq(&oid, &ce->oid);

--- a/tarballpatches/utf8.c.patch
+++ b/tarballpatches/utf8.c.patch
@@ -1,0 +1,22 @@
+diff --git a/utf8.c b/utf8.c
+index de4ce5c..490cdd8 100644
+--- a/utf8.c
++++ b/utf8.c
+@@ -581,6 +581,17 @@ char *reencode_string_len(const char *in, size_t insz,
+ #endif
+ 	}
+ 
++#ifdef __MVS__
++  //HACK: For backwards compat, ISO8859-1 really means utf-8 in the z/OS world
++  if (strcasecmp("ISO8859-1", in_encoding) == 0) {
++    in_encoding = "UTF-8";
++    out_encoding = "UTF-8";
++  }
++  if (strcasecmp("ISO8859-1", out_encoding) == 0) {
++    in_encoding = "UTF-8";
++    out_encoding = "UTF-8";
++  }
++#endif
+ 	conv = iconv_open(out_encoding, in_encoding);
+ 	if (conv == (iconv_t) -1) {
+ 		in_encoding = fallback_encoding(in_encoding);

--- a/tests/testtags.sh
+++ b/tests/testtags.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
+set -e
 
 mydir=$(cd $(dirname $0) && echo $PWD)
-
 
 # The following is a bit hokey... might not always work
 #
@@ -30,16 +30,22 @@ cat > expected.txt <<ZZ
 t IBM-1047    T=on  README.md
 b binary      T=off a.png
 t ISO8859-1   T=on  ascii.txt
+t ISO8859-1   T=on  cacert.pem
+t IBM-037     T=on  my_037.txt
 ZZ
 cd EBCDICProject
 chtag -p * > ../actual.txt
-cat README.md ascii.txt > ../actual2.txt
+iconv -f IBM-037 -t IBM-1047 my_037.txt > my_1047.txt
+chtag -tc 1047 my_1047.txt
+cat README.md ascii.txt my_1047.txt > ../actual2.txt
 cd ..
 diff actual.txt expected.txt
 
 cat > expected2.txt <<ZZ
 Hello World
 Hello World
+Hello World []
 ZZ
 diff actual2.txt expected2.txt
+
 

--- a/tests/testtags.sh
+++ b/tests/testtags.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+mydir=$(cd $(dirname $0) && echo $PWD)
+
+
+# The following is a bit hokey... might not always work
+#
+gitdir="${mydir}/../git-2.38.1"
+echo $gitdir
+if ! [ -d "${gitdir}" ] ; then
+  echo "Unable to find git dev driver" >&2
+  exit 99
+fi
+absgitdir=$(cd ${gitdir} && echo $PWD)
+
+export PATH=/bin:/usr/bin:${absgitdir}
+
+tmpdir="/tmp/git-$$"
+mkdir "${tmpdir}" || exit 99             
+cd "${tmpdir}" || exit 99
+touch ".gitconfig" || exit 99
+echo $PWD
+
+export GIT_TEMPLATE_DIR="${mydir}/../git-2.38.1/templates/blt"
+export GIT_EXEC_PATH="${mydir}/../git-2.38.1/libexec/git-core"
+gitrepourl="git@github.com:IgorTodorovskiIBM/EBCDICProject.git"
+git clone $gitrepourl
+
+cat > expected.txt <<ZZ
+t IBM-1047    T=on  README.md
+b binary      T=off a.png
+t ISO8859-1   T=on  ascii.txt
+ZZ
+cd EBCDICProject
+chtag -p * > ../actual.txt
+cd ..
+diff actual.txt expected.txt

--- a/tests/testtags.sh
+++ b/tests/testtags.sh
@@ -33,5 +33,13 @@ t ISO8859-1   T=on  ascii.txt
 ZZ
 cd EBCDICProject
 chtag -p * > ../actual.txt
+cat README.md ascii.txt > ../actual2.txt
 cd ..
 diff actual.txt expected.txt
+
+cat > expected2.txt <<ZZ
+Hello World
+Hello World
+ZZ
+diff actual2.txt expected2.txt
+


### PR DESCRIPTION
* Leverages the existing working-tree-encoding support from Git
* Adds file tagging support, such that files are tagged according to the working-tree-encoding
* Tested with this repo: https://github.com/IgorTodorovskiIBM/EBCDICProject and this attributes file: https://github.com/IgorTodorovskiIBM/EBCDICProject/blob/main/.gitattributes as well as several ZOSOpenTools repos