### PR TITLE
Add platform-working-tree-encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ to convert all files from Git's internal UTF-8 encoding to IBM-1047, you can spe
 ```
 This will result in Git on z/OS tagging all files as IBM-1047 on checkout. 
 
+If you want the working-tree-encoding to apply to the host platform only, then you can use:
+`platform-working-tree-encoding` where platform is substituted with the system name.
+
+On z/OS, platform is `zos`. Therefore, the .gitattributes would be:
+```
+* text zos-working-tree-encoding=IBM-1047
+```
+
 If no encoding is specified, the default UTF-8 encoding is used and all files are tagged as ISO8859-1. 
 
 To find out all of the supported encodings, run `iconv -l`.
@@ -36,10 +44,3 @@ You can specify multiple working-tree-encoding attributes, where the later attri
 When adding files, you need to make sure that the z/OS file tag matches the working-tree-encoding. Otherwise, you may encounter an error.
 
 NOTE: Git on z/OS does not currently support adding `untagged` files.
-
-### Comparison to Rocket Software's Git
-Rocket Software implemented `zos-working-tree-encoding`, including it's synonym `working-tree-encoding`. Git on z/OS does not support zos-working-tree-encoding.
-Furthermore, Rocket Software implemented zos-working-tree-encoding from scratch, while Git on z/OS leverages the Git's official working-tree-encoding support.
-
-Binary files are also handled differently. With Rocket's Git, `zos-working-tree-encoding=BINARY` must be specified to ensure a file is tagged as binary. 
-Git on z/OS leverages the `binary` keyword, which is officially supported by Git.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ On z/OS, platform is `zos`. Therefore, the .gitattributes would be:
 
 If no encoding is specified, the default UTF-8 encoding is used and all files are tagged as ISO8859-1. 
 
-To find out all of the supported encodings, run `iconv -l`.
+To find out all of the supported encodings by git, run `iconv -l`.
+
+When adding files, you need to make sure that the z/OS file tag matches the working-tree-encoding. Otherwise, you may encounter an error.
 
 ### Binary files
 To specify a binary encoding, you can use the binary attribute as follows:
@@ -33,6 +35,10 @@ To specify a binary encoding, you can use the binary attribute as follows:
 ```
 This will tag all `*.png` files as binary.
 
+### Untagged files
+Git on z/OS does not currently support adding `untagged` files. Files need to be tagged before
+they can be added.
+
 ### Multiple encodings
 You can specify multiple working-tree-encoding attributes, where the later attributes overrides the initial attributes in case of an overlap.
 ```
@@ -40,7 +46,7 @@ You can specify multiple working-tree-encoding attributes, where the later attri
 *.png binary
 ```
 
-### Gotchas
-When adding files, you need to make sure that the z/OS file tag matches the working-tree-encoding. Otherwise, you may encounter an error.
+### Migration considerations
+If you are migrating from Rocket Software's Git, then the good news is that Git on z/OS should be compatible. 
 
-NOTE: Git on z/OS does not currently support adding `untagged` files.
+If you encounter any issues, please open an issue under https://github.com/ZOSOpenTools/gitport/issues.

--- a/tarballpatches/convert.c.patch
+++ b/tarballpatches/convert.c.patch
@@ -1,0 +1,53 @@
+diff --git a/convert.c b/convert.c
+index 95e6a52..b5eb8d2 100644
+--- a/convert.c
++++ b/convert.c
+@@ -1293,20 +1293,38 @@ static int git_path_check_ident(struct attr_check_item *check)
+ 	return !!ATTR_TRUE(value);
+ }
+ 
++static const char* get_platform() {
++	struct utsname uname_info;
++
++	if (uname(&uname_info))
++		die(_("uname() failed with error '%s' (%d)\n"),
++			    strerror(errno),
++			    errno);
++
++  if (!strcmp(uname_info.sysname, "OS/390"))
++    return "zos";
++  return uname_info.sysname;
++}
++
++
+ static struct attr_check *check;
+ 
+ void convert_attrs(struct index_state *istate,
+ 		   struct conv_attrs *ca, const char *path)
+ {
+ 	struct attr_check_item *ccheck = NULL;
++	struct strbuf platform_working_tree_encoding = STRBUF_INIT;
++
++	strbuf_addf(&platform_working_tree_encoding, "%s-working-tree-encoding", get_platform());
+ 
+ 	if (!check) {
+ 		check = attr_check_initl("crlf", "ident", "filter",
+-					 "eol", "text", "working-tree-encoding",
++					 "eol", "text", "working-tree-encoding", platform_working_tree_encoding.buf,
+ 					 NULL);
+ 		user_convert_tail = &user_convert;
+ 		git_config(read_convert_config, NULL);
+ 	}
++	strbuf_release(&platform_working_tree_encoding);
+ 
+ 	git_check_attr(istate, path, check);
+ 	ccheck = check->items;
+@@ -1327,6 +1345,8 @@ void convert_attrs(struct index_state *istate,
+ 			ca->crlf_action = CRLF_TEXT_CRLF;
+ 	}
+ 	ca->working_tree_encoding = git_path_check_encoding(ccheck + 5);
++  if (git_path_check_encoding(ccheck + 6))
++    ca->working_tree_encoding = git_path_check_encoding(ccheck + 6);
+ 
+ 	/* Save attr and make a decision for action */
+ 	ca->attr_action = ca->crlf_action;


### PR DESCRIPTION
Adds support for [platform]-working-tree-encoding.

Platform is substituted with `uname_info.sysname`, so it will only apply to the given platform.

Example: https://github.com/IgorTodorovskiIBM/EBCDICProject/blob/main/.gitattributes

This will make it compatible with Rocket's Git, but also more generic so that other platform's can make use of it if needed.

