### PR TITLE
Support for core.ignorefiletags + perl fix

### DIFF
--- a/tarballpatches/Makefile.patch
+++ b/tarballpatches/Makefile.patch
@@ -1,3 +1,89 @@
+diff --git a/Makefile b/Makefile
+index cac3452..c70a236 100644
+--- a/Makefile
++++ b/Makefile
+@@ -8,6 +8,8 @@ include shared.mak
+ #
+ # Define SHELL_PATH to a POSIX shell if your /bin/sh is broken.
+ #
++# Define SHELL_PATH_FOR_SCRIPTS to a POSIX shell if your /bin/sh is broken.
++#
+ # Define SANE_TOOL_PATH to a colon-separated list of paths to prepend
+ # to PATH if your tools in /usr/bin are broken.
+ #
+@@ -300,6 +302,8 @@ include shared.mak
+ #
+ # Define PERL_PATH to the path of your Perl binary (usually /usr/bin/perl).
+ #
++# Define PERL_PATH_FOR_SCRIPTS to a Perl binary if your /usr/bin/perl is broken.
++#
+ # Define NO_PERL if you do not want Perl scripts or libraries at all.
+ #
+ # Define NO_PERL_CPAN_FALLBACKS if you do not want to install bundled
+@@ -839,9 +843,15 @@ BINDIR_PROGRAMS_NO_X += git-cvsserver
+ ifndef SHELL_PATH
+ 	SHELL_PATH = /bin/sh
+ endif
++ifndef SHELL_PATH_FOR_SCRIPTS
++	SHELL_PATH_FOR_SCRIPTS = /bin/sh
++endif
+ ifndef PERL_PATH
+ 	PERL_PATH = /usr/bin/perl
+ endif
++ifndef PERL_PATH_FOR_SCRIPTS
++	PERL_PATH_FOR_SCRIPTS = /usr/bin/perl
++endif
+ ifndef PYTHON_PATH
+ 	PYTHON_PATH = /usr/bin/python
+ endif
+@@ -1268,7 +1278,7 @@ THIRD_PARTY_SOURCES += sha1dc/%
+ 
+ # xdiff and reftable libs may in turn depend on what is in libgit.a
+ GITLIBS = common-main.o $(LIB_FILE) $(XDIFF_LIB) $(REFTABLE_LIB) $(LIB_FILE)
+-EXTLIBS =
++EXTLIBS = $(ZOPEN_EXTRA_LIBS)
+ 
+ GIT_USER_AGENT = git/$(GIT_VERSION)
+ 
+@@ -2110,9 +2120,10 @@ perllibdir_relative_SQ = $(subst ','\'',$(perllibdir_relative))
+ gitwebdir_SQ = $(subst ','\'',$(gitwebdir))
+ gitwebstaticdir_SQ = $(subst ','\'',$(gitwebstaticdir))
+ 
+-SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH))
++SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH_FOR_SCRIPTS))
+ TEST_SHELL_PATH_SQ = $(subst ','\'',$(TEST_SHELL_PATH))
+ PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH))
++PERL_PATH_FOR_SCRIPTS_SQ = $(subst ','\'',$(PERL_PATH_FOR_SCRIPTS))
+ PYTHON_PATH_SQ = $(subst ','\'',$(PYTHON_PATH))
+ TCLTK_PATH_SQ = $(subst ','\'',$(TCLTK_PATH))
+ DIFF_SQ = $(subst ','\'',$(DIFF))
+@@ -2332,7 +2343,7 @@ hook-list.h: generate-hooklist.sh Documentation/githooks.txt
+ 
+ SCRIPT_DEFINES = $(SHELL_PATH_SQ):$(DIFF_SQ):\
+ 	$(localedir_SQ):$(USE_GETTEXT_SCHEME):$(SANE_TOOL_PATH_SQ):\
+-	$(gitwebdir_SQ):$(PERL_PATH_SQ):$(PAGER_ENV):\
++	$(gitwebdir_SQ):$(PERL_PATH_FOR_SCRIPTS_SQ):$(PAGER_ENV):\
+ 	$(perllibdir_SQ)
+ GIT-SCRIPT-DEFINES: FORCE
+ 	@FLAGS='$(SCRIPT_DEFINES)'; \
+@@ -2349,7 +2360,7 @@ sed -e '1s|#!.*/sh|#!$(SHELL_PATH_SQ)|' \
+     -e 's/@@USE_GETTEXT_SCHEME@@/$(USE_GETTEXT_SCHEME)/g' \
+     -e $(BROKEN_PATH_FIX) \
+     -e 's|@@GITWEBDIR@@|$(gitwebdir_SQ)|g' \
+-    -e 's|@@PERL@@|$(PERL_PATH_SQ)|g' \
++    -e 's|@@PERL@@|$(PERL_PATH_FOR_SCRIPTS_SQ)|g' \
+     -e 's|@@PAGER_ENV@@|$(PAGER_ENV_SQ)|g' \
+     $@.sh >$@+
+ endef
+@@ -2403,7 +2414,7 @@ PERL_DEFINES += $(gitexecdir) $(perllibdir) $(localedir)
+ $(SCRIPT_PERL_GEN): % : %.perl GIT-PERL-DEFINES GIT-PERL-HEADER GIT-VERSION-FILE
+ 	$(QUIET_GEN) \
+ 	sed -e '1{' \
+-	    -e '	s|#!.*perl|#!$(PERL_PATH_SQ)|' \
++	    -e '	s|#!.*perl|#!$(PERL_PATH_FOR_SCRIPTS_SQ)|' \
+ 	    -e '	r GIT-PERL-HEADER' \
+ 	    -e '	G' \
+ 	    -e '}' \
 diff --git a/git-gui/Makefile b/git-gui/Makefile
 index 56c85a8..72934a9 100644
 --- a/git-gui/Makefile
@@ -48,10 +134,10 @@ index 882782a..bacb8ef 100644
  PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH))
  TEST_RESULTS_DIRECTORY_SQ = $(subst ','\'',$(TEST_RESULTS_DIRECTORY))
 diff --git a/templates/Makefile b/templates/Makefile
-index 367ad00..f7837d7 100644
+index 367ad00..251ba68 100644
 --- a/templates/Makefile
 +++ b/templates/Makefile
-@@ -12,11 +12,14 @@ template_instdir ?= $(prefix)/share/git-core/templates
+@@ -12,12 +12,18 @@ template_instdir ?= $(prefix)/share/git-core/templates
  ifndef SHELL_PATH
  	SHELL_PATH = /bin/sh
  endif
@@ -61,50 +147,14 @@ index 367ad00..f7837d7 100644
  ifndef PERL_PATH
  	PERL_PATH = perl
  endif
++ifndef PERL_PATH_FOR_SCRIPTS
++	PERL_PATH_FOR_SCRIPTS = /usr/bin/perl
++endif
  
 -SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH))
+-PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH))
 +SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH_FOR_SCRIPTS))
- PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH))
++PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH_FOR_SCRIPTS))
  
  # Shell quote (do not use $(call) to accommodate ancient setups);
-diff --git a/Makefile b/Makefile
-index cac3452..76647ac 100644
---- a/Makefile
-+++ b/Makefile
-@@ -8,6 +8,8 @@ include shared.mak
- #
- # Define SHELL_PATH to a POSIX shell if your /bin/sh is broken.
- #
-+# Define SHELL_PATH_FOR_SCRIPTS to a POSIX shell if your /bin/sh is broken.
-+#
- # Define SANE_TOOL_PATH to a colon-separated list of paths to prepend
- # to PATH if your tools in /usr/bin are broken.
- #
-@@ -839,6 +841,9 @@ BINDIR_PROGRAMS_NO_X += git-cvsserver
- ifndef SHELL_PATH
- 	SHELL_PATH = /bin/sh
- endif
-+ifndef SHELL_PATH_FOR_SCRIPTS
-+	SHELL_PATH_FOR_SCRIPTS = /bin/sh
-+endif
- ifndef PERL_PATH
- 	PERL_PATH = /usr/bin/perl
- endif
-@@ -1268,7 +1273,7 @@ THIRD_PARTY_SOURCES += sha1dc/%
- 
- # xdiff and reftable libs may in turn depend on what is in libgit.a
- GITLIBS = common-main.o $(LIB_FILE) $(XDIFF_LIB) $(REFTABLE_LIB) $(LIB_FILE)
--EXTLIBS =
-+EXTLIBS = $(ZOPEN_EXTRA_LIBS)
- 
- GIT_USER_AGENT = git/$(GIT_VERSION)
- 
-@@ -2110,7 +2115,7 @@ perllibdir_relative_SQ = $(subst ','\'',$(perllibdir_relative))
- gitwebdir_SQ = $(subst ','\'',$(gitwebdir))
- gitwebstaticdir_SQ = $(subst ','\'',$(gitwebstaticdir))
- 
--SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH))
-+SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH_FOR_SCRIPTS))
- TEST_SHELL_PATH_SQ = $(subst ','\'',$(TEST_SHELL_PATH))
- PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH))
- PYTHON_PATH_SQ = $(subst ','\'',$(PYTHON_PATH))
+ DESTDIR_SQ = $(subst ','\'',$(DESTDIR))

--- a/tarballpatches/cache.h.patch
+++ b/tarballpatches/cache.h.patch
@@ -1,0 +1,15 @@
+diff --git a/cache.h b/cache.h
+index 26ed03b..4ea2592 100644
+--- a/cache.h
++++ b/cache.h
+@@ -1066,6 +1066,10 @@ extern enum fsync_component fsync_components;
+ extern int fsync_object_files;
+ extern int use_fsync;
+ 
++#ifdef __MVS__
++extern int ignore_file_tags;
++#endif
++
+ enum fsync_method {
+ 	FSYNC_METHOD_FSYNC,
+ 	FSYNC_METHOD_WRITEOUT_ONLY,

--- a/tarballpatches/config.c.patch
+++ b/tarballpatches/config.c.patch
@@ -1,15 +1,17 @@
 diff --git a/config.c b/config.c
-index cbb5a3b..b74ceb5 100644
+index cbb5a3b..a68d2aa 100644
 --- a/config.c
 +++ b/config.c
-@@ -1623,6 +1623,11 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
+@@ -1623,6 +1623,13 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
  		return 0;
  	}
  
++#ifdef __MVS__
 +	if (!strcmp(var, "core.ignorefiletags")) {
 +		ignore_file_tags = git_config_bool(var, value);
 +		return 0;
 +	}
++#endif
 +
  	if (!strcmp(var, "core.safecrlf")) {
  		int eol_rndtrp_die;

--- a/tarballpatches/config.c.patch
+++ b/tarballpatches/config.c.patch
@@ -1,0 +1,16 @@
+diff --git a/config.c b/config.c
+index cbb5a3b..b74ceb5 100644
+--- a/config.c
++++ b/config.c
+@@ -1623,6 +1623,11 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
+ 		return 0;
+ 	}
+ 
++	if (!strcmp(var, "core.ignorefiletags")) {
++		ignore_file_tags = git_config_bool(var, value);
++		return 0;
++	}
++
+ 	if (!strcmp(var, "core.safecrlf")) {
+ 		int eol_rndtrp_die;
+ 		if (value && !strcasecmp(value, "warn")) {

--- a/tarballpatches/config.mak.uname.patch
+++ b/tarballpatches/config.mak.uname.patch
@@ -1,5 +1,5 @@
 diff --git a/config.mak.uname b/config.mak.uname
-index d63629f..70bd89c 100644
+index d63629f..68a7389 100644
 --- a/config.mak.uname
 +++ b/config.mak.uname
 @@ -362,7 +362,7 @@ ifeq ($(uname_S),IRIX)
@@ -11,17 +11,18 @@ index d63629f..70bd89c 100644
  	NEEDS_LIBGEN = YesPlease
  endif
  ifeq ($(uname_S),IRIX64)
-@@ -622,6 +622,27 @@ ifeq ($(uname_S),NONSTOP_KERNEL)
+@@ -622,6 +622,28 @@ ifeq ($(uname_S),NONSTOP_KERNEL)
  	SANE_TOOL_PATH = /usr/coreutils/bin:/usr/local/bin
  	SHELL_PATH = /usr/coreutils/bin/bash
  endif
 +
 +ifeq ($(uname_S),OS/390)
 +  V = 2
-+	PERL_PATH = /bin/env perl
++	PERL_PATH = perl
++	PERL_PATH_FOR_SCRIPTS = /bin/env perl
 +	SHELL_PATH = bash
 +	SHELL_PATH_FOR_SCRIPTS = /bin/env bash
-+	PYTHON_PATH = /bin/env python3
++	PYTHON_PATH = python
 +  NO_SYS_POLL_H = YesPlease
 +  NO_STRCASESTR = YesPlease
 +  NO_REGEX = YesPlease

--- a/tarballpatches/config.mak.uname.patch
+++ b/tarballpatches/config.mak.uname.patch
@@ -1,5 +1,5 @@
 diff --git a/config.mak.uname b/config.mak.uname
-index d63629f..a87e7eb 100644
+index d63629f..70bd89c 100644
 --- a/config.mak.uname
 +++ b/config.mak.uname
 @@ -362,7 +362,7 @@ ifeq ($(uname_S),IRIX)
@@ -18,10 +18,10 @@ index d63629f..a87e7eb 100644
 +
 +ifeq ($(uname_S),OS/390)
 +  V = 2
-+	PERL_PATH = perl
++	PERL_PATH = /bin/env perl
 +	SHELL_PATH = bash
 +	SHELL_PATH_FOR_SCRIPTS = /bin/env bash
-+	PYTHON_PATH = python
++	PYTHON_PATH = /bin/env python3
 +  NO_SYS_POLL_H = YesPlease
 +  NO_STRCASESTR = YesPlease
 +  NO_REGEX = YesPlease

--- a/tarballpatches/environment.c.patch
+++ b/tarballpatches/environment.c.patch
@@ -1,0 +1,14 @@
+diff --git a/environment.c b/environment.c
+index 18d042b..b268cd3 100644
+--- a/environment.c
++++ b/environment.c
+@@ -43,6 +43,9 @@ const char *git_hooks_path;
+ int zlib_compression_level = Z_BEST_SPEED;
+ int pack_compression_level = Z_DEFAULT_COMPRESSION;
+ int fsync_object_files = -1;
++#ifdef __MVS__
++int ignore_file_tags = 0;
++#endif
+ int use_fsync = -1;
+ enum fsync_method fsync_method = FSYNC_METHOD_DEFAULT;
+ enum fsync_component fsync_components = FSYNC_COMPONENTS_DEFAULT;

--- a/tarballpatches/object-file.c.patch
+++ b/tarballpatches/object-file.c.patch
@@ -1,5 +1,5 @@
 diff --git a/object-file.c b/object-file.c
-index 5b270f0..1b8626e 100644
+index 5b270f0..9aefc37 100644
 --- a/object-file.c
 +++ b/object-file.c
 @@ -8,6 +8,7 @@
@@ -21,7 +21,7 @@ index 5b270f0..1b8626e 100644
  /* The maximum size for an object header. */
  #define MAX_HEADER_LEN 32
  
-@@ -2499,18 +2504,87 @@ int index_fd(struct index_state *istate, struct object_id *oid,
+@@ -2499,18 +2504,86 @@ int index_fd(struct index_state *istate, struct object_id *oid,
  	return ret;
  }
  
@@ -31,21 +31,16 @@ index 5b270f0..1b8626e 100644
 +  struct stat st;
 +  unsigned short attr_ccsid;
 +  unsigned short file_ccsid;
++
++  if (ignore_file_tags)
++    return;
++
 +  *autoconvertToASCII = 0;
 +	convert_attrs(istate, &ca, path);
-+#if DEBUG
-+    fprintf(stderr, "Processing %s\n", path);
-+#endif
 +  if (ca.attr_action == CRLF_BINARY) {
-+#if DEBUG
-+    fprintf(stderr, "Is binary");
-+#endif
 +    attr_ccsid = FT_BINARY;
 +  }
 +  else if (ca.working_tree_encoding) {
-+#if DEBUG
-+    fprintf(stderr, "Working-tree-encoding %s\n", ca.working_tree_encoding);
-+#endif
 +    attr_ccsid = __toCcsid(ca.working_tree_encoding);
 +  }
 +  else
@@ -68,6 +63,10 @@ index 5b270f0..1b8626e 100644
 +    if (file_ccsid == 819 && attr_ccsid == 1208) {
 +      return;
 +    }
++    // Don't check for binary files, just add them
++    if (attr_ccsid == FT_BINARY)
++      return;
++
 +    char attr_csname[_XOPEN_PATH_MAX] = {0};
 +    char file_csname[_XOPEN_PATH_MAX] = {0};
 +    if (attr_ccsid != FT_BINARY) {


### PR DESCRIPTION
* Fixes shebang line for perl, changes it to /bin/env perl for z/OS
* Adds support for core.ignorefiletags, where if set to true, it will ignore checking of file tags before adding it to git. Default is false.
* Also, ignore the file tag for binary files to match Rocket behaviour

```
# Default:
[ITODORO@ZOSCAN2B ~/zopen/prod/git/new_tests]$ cat .gitattributes
* text zos-working-tree-encoding=IBM-1047
my_037.txt text zos-working-tree-encoding=IBM-037
ascii.txt text zos-working-tree-encoding=ISO8859-1
cacert.pem text zos-working-tree-encoding=UTF-8
cacert.pem2 text zos-working-tree-encoding=ISO8859-1
a.png binary
[ITODORO@ZOSCAN2B ~/zopen/prod/git/new_tests]$ chtag -tc 037 ascii.txt
[ITODORO@ZOSCAN2B ~/zopen/prod/git/new_tests]$ git add ascii.txt
fatal: ascii.txt added file: file tag (IBM-037) does not match working-tree-encoding (ISO8859-1)
```

When ignorefiletags is set to true, no error is printed out for the mismatch in file tags
```
[ITODORO@ZOSCAN2B ~/zopen/prod/git/new_tests]$ git config --global core.ignorefiletags true
[ITODORO@ZOSCAN2B ~/zopen/prod/git/new_tests]$ chtag -tc 037 ascii.txt
[ITODORO@ZOSCAN2B ~/zopen/prod/git/new_tests]$ git add ascii.txt
[ITODORO@ZOSCAN2B ~/zopen/prod/git/new_tests]$
```