### PR TITLE
Fix binary failing to encode error

### DIFF
--- a/tarballpatches/convert.c.patch
+++ b/tarballpatches/convert.c.patch
@@ -1,8 +1,25 @@
 diff --git a/convert.c b/convert.c
-index 95e6a52..65d5c5f 100644
+index 95e6a52..eba9a48 100644
 --- a/convert.c
 +++ b/convert.c
-@@ -396,6 +396,11 @@ static int encode_to_git(const char *path, const char *src, size_t src_len,
+@@ -370,12 +370,15 @@ static int check_roundtrip(const char *enc_name)
+ static const char *default_encoding = "UTF-8";
+ 
+ static int encode_to_git(const char *path, const char *src, size_t src_len,
+-			 struct strbuf *buf, const char *enc, int conv_flags)
++			 struct strbuf *buf, const char *enc, enum convert_crlf_action attr_action, int conv_flags)
+ {
+ 	char *dst;
+ 	size_t dst_len;
+ 	int die_on_error = conv_flags & CONV_WRITE_OBJECT;
+ 
++  if (attr_action == CRLF_BINARY) {
++    return 0;
++  }
+ 	/*
+ 	 * No encoding is specified or there is nothing to encode.
+ 	 * Tell the caller that the content was not modified.
+@@ -396,6 +399,11 @@ static int encode_to_git(const char *path, const char *src, size_t src_len,
  		return 0;
  
  	trace_encoding("source", path, enc, src, src_len);
@@ -14,7 +31,23 @@ index 95e6a52..65d5c5f 100644
  	dst = reencode_string_len(src, src_len, default_encoding, enc,
  				  &dst_len);
  	if (!dst) {
-@@ -1293,20 +1298,38 @@ static int git_path_check_ident(struct attr_check_item *check)
+@@ -461,11 +469,14 @@ static int encode_to_git(const char *path, const char *src, size_t src_len,
+ }
+ 
+ static int encode_to_worktree(const char *path, const char *src, size_t src_len,
+-			      struct strbuf *buf, const char *enc)
++			      struct strbuf *buf, enum convert_crlf_action attr_action, const char *enc)
+ {
+ 	char *dst;
+ 	size_t dst_len;
+ 
++  if (attr_action == CRLF_BINARY) {
++    return 0;
++  }
+ 	/*
+ 	 * No encoding is specified or there is nothing to encode.
+ 	 * Tell the caller that the content was not modified.
+@@ -1293,20 +1304,38 @@ static int git_path_check_ident(struct attr_check_item *check)
  	return !!ATTR_TRUE(value);
  }
  
@@ -54,7 +87,7 @@ index 95e6a52..65d5c5f 100644
  
  	git_check_attr(istate, path, check);
  	ccheck = check->items;
-@@ -1327,6 +1350,8 @@ void convert_attrs(struct index_state *istate,
+@@ -1327,6 +1356,8 @@ void convert_attrs(struct index_state *istate,
  			ca->crlf_action = CRLF_TEXT_CRLF;
  	}
  	ca->working_tree_encoding = git_path_check_encoding(ccheck + 5);
@@ -63,3 +96,30 @@ index 95e6a52..65d5c5f 100644
  
  	/* Save attr and make a decision for action */
  	ca->attr_action = ca->crlf_action;
+@@ -1420,7 +1451,7 @@ int convert_to_git(struct index_state *istate,
+ 		len = dst->len;
+ 	}
+ 
+-	ret |= encode_to_git(path, src, len, dst, ca.working_tree_encoding, conv_flags);
++	ret |= encode_to_git(path, src, len, dst, ca.working_tree_encoding, ca.attr_action, conv_flags);
+ 	if (ret && dst) {
+ 		src = dst->buf;
+ 		len = dst->len;
+@@ -1448,7 +1479,7 @@ void convert_to_git_filter_fd(struct index_state *istate,
+ 	if (!apply_filter(path, NULL, 0, fd, dst, ca.drv, CAP_CLEAN, NULL, NULL))
+ 		die(_("%s: clean filter '%s' failed"), path, ca.drv->name);
+ 
+-	encode_to_git(path, dst->buf, dst->len, dst, ca.working_tree_encoding, conv_flags);
++	encode_to_git(path, dst->buf, dst->len, dst, ca.working_tree_encoding, ca.attr_action, conv_flags);
+ 	crlf_to_git(istate, path, dst->buf, dst->len, dst, ca.crlf_action, conv_flags);
+ 	ident_to_git(dst->buf, dst->len, dst, ca.ident);
+ }
+@@ -1480,7 +1511,7 @@ static int convert_to_working_tree_ca_internal(const struct conv_attrs *ca,
+ 		}
+ 	}
+ 
+-	ret |= encode_to_worktree(path, src, len, dst, ca->working_tree_encoding);
++	ret |= encode_to_worktree(path, src, len, dst, ca->attr_action, ca->working_tree_encoding);
+ 	if (ret) {
+ 		src = dst->buf;
+ 		len = dst->len;


### PR DESCRIPTION
* Resolves the issue with binary attributed files failing to encode to a working-tree-encoding (e.g. when cloning zotsampleport)
* This was uncovered by David Shackelford who was attempted to build zotsampleport with this version of Git on z/OS