### PR TITLE
cacert automation support for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ git
 patches
 log
 install
-git-2.38.1
-v2.38.1
+git-2.39.1
+v2.39.1
 git-compat-util

--- a/buildenv
+++ b/buildenv
@@ -70,5 +70,20 @@ unset GIT_ROOT
 unset GIT_SHELL
 export GIT_TEMPLATE_DIR="\$PWD/share/git-core/templates"
 export GIT_EXEC_PATH="\$PWD/libexec/git-core/"
+if [ "\${GIT_SSL_CAINFO}x" = "x" ]; then
+  if [ -f "\$PWD/cacert.pem" ]; then
+    export GIT_SSL_CAINFO="\$PWD/cacert.pem"
+  else
+    echo "Warning: you need to set GIT_SSL_CAINFO to a pem file if you want to use git with SSH" >&2
+  fi
+fi
+EOF
+}
+
+zopen_append_to_setup() {
+cat <<EOF
+if [ -f "\$PWD/../cacert.pem" ]; then
+  cp "\$PWD/../cacert.pem" "\$PWD/cacert.pem"
+fi
 EOF
 }


### PR DESCRIPTION
fix up gitignore and add in code to copy the cacert.pem from the 'root' zopen/<type> directory to myself and then set the IT_SSL_CAINFO env var