### PR TITLE
Use __getenv to fix git identification issues with envars

### DIFF
--- a/tarballpatches/git-compat-util.h.patch
+++ b/tarballpatches/git-compat-util.h.patch
@@ -1,0 +1,17 @@
+diff --git a/git-compat-util.h b/git-compat-util.h
+index af05077..ecc35a4 100644
+--- a/git-compat-util.h
++++ b/git-compat-util.h
+@@ -1508,6 +1508,12 @@ int git_access(const char *path, int mode);
+ # endif
+ #endif
+ 
++
++#ifdef __MVS__
++/* On z/OS, getenv does not return a unique pointer, use __getenv instead
++ */
++#define getenv __getenv
++#endif
+ /*
+  * Our code often opens a path to an optional file, to work on its
+  * contents when we can successfully open it.  We can ignore a failure


### PR DESCRIPTION
This resolves https://github.com/ZOSOpenTools/gitport/issues/42