### PR TITLE
Append environment variables to be set before main

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -165,6 +165,17 @@ zopen_post_install()
   fi
 }
 
+zopen_append_to_zoslib_env() {
+cat <<EOF
+GIT_MAN_PATH|unset|
+GIT_ROOT|unset|
+GIT_SHELL|unset|
+GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
+GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
+GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
+EOF
+}
+
 zopen_get_version() {
   ./git --version | awk -F" " '{print $3}'
 }

--- a/buildenv
+++ b/buildenv
@@ -167,9 +167,6 @@ zopen_post_install()
 
 zopen_append_to_zoslib_env() {
 cat <<EOF
-GIT_MAN_PATH|unset|
-GIT_ROOT|unset|
-GIT_SHELL|unset|
 GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
 GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
 GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem


### PR DESCRIPTION
* This enables git to run without having to source the .env