### PR TITLE
Add support for clang + move to git 2.40.1

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -3,7 +3,7 @@
 #
 export ZOPEN_TYPE="TARBALL"
 
-GIT_VERSION="2.39.2"
+GIT_VERSION="2.40.1"
 
 export ZOPEN_GIT_URL="https://github.com/git/git"
 export ZOPEN_GIT_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext coreutils diffutils bash"
@@ -13,7 +13,6 @@ export ZOPEN_TARBALL_DEPS="curl git make m4 perl autoconf automake help2man texi
 
 #
 # Note the 'man' tarball release is numbered independently from the 'git' release.
-# 2.9.5 is the latest 'man' tarball and 2.39.1 is the latest 'git' tarball (right now)
 #
 export ZOPEN_TARBALL_MAN_URL="https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-${GIT_VERSION}.tar.xz"
 
@@ -70,6 +69,8 @@ zopen_install_all()
   if [ $? -gt 0 ]; then
     return 4;
   fi
+  # Copy new contributor tools git-jump as per instructions
+  cp contrib/git-jump/git-jump $ZOPEN_INSTALL_DIR/bin
 }
 # Run a 'zopen_pre_check' routine to clean out any GIT environment variables 
 # that might interfere with a new GIT operation during the test run

--- a/tarballpatches/config.mak.uname.patch
+++ b/tarballpatches/config.mak.uname.patch
@@ -1,28 +1,17 @@
 diff --git a/config.mak.uname b/config.mak.uname
-index d63629f..68a7389 100644
+index 64c44db..1caa1f5 100644
 --- a/config.mak.uname
 +++ b/config.mak.uname
-@@ -362,7 +362,7 @@ ifeq ($(uname_S),IRIX)
- 	NO_MMAP = YesPlease
- 	NO_REGEX = YesPlease
- 	SNPRINTF_RETURNS_BOGUS = YesPlease
--	SHELL_PATH = /usr/gnu/bin/bash
-+	SHELL_PATH = "/bin/env bash"
- 	NEEDS_LIBGEN = YesPlease
- endif
- ifeq ($(uname_S),IRIX64)
-@@ -622,6 +622,28 @@ ifeq ($(uname_S),NONSTOP_KERNEL)
+@@ -623,6 +623,24 @@ ifeq ($(uname_S),NONSTOP_KERNEL)
  	SANE_TOOL_PATH = /usr/coreutils/bin:/usr/local/bin
  	SHELL_PATH = /usr/coreutils/bin/bash
  endif
-+
 +ifeq ($(uname_S),OS/390)
-+  V = 2
-+	PERL_PATH = perl
-+	PERL_PATH_FOR_SCRIPTS = /bin/env perl
-+	SHELL_PATH = bash
-+	SHELL_PATH_FOR_SCRIPTS = /bin/env bash
-+	PYTHON_PATH = python
++  PERL_PATH = perl
++  PERL_PATH_FOR_SCRIPTS = /bin/env perl
++  SHELL_PATH = bash
++  SHELL_PATH_FOR_SCRIPTS = /bin/env bash
++  PYTHON_PATH = python
 +  NO_SYS_POLL_H = YesPlease
 +  NO_STRCASESTR = YesPlease
 +  NO_REGEX = YesPlease
@@ -33,10 +22,8 @@ index d63629f..68a7389 100644
 +  NO_MEMMEM = YesPlease
 +  NO_GECOS_IN_PWENT = YesPlease
 +  HAVE_STRINGS_H = YesPlease
-+  PTHREAD_LIBS =
 +  NEEDS_MODE_TRANSLATION = YesPlease
 +endif
-+
  ifeq ($(uname_S),MINGW)
- 	pathsep = ;
- 	HAVE_ALLOCA_H = YesPlease
+ 	ifeq ($(shell expr "$(uname_R)" : '1\.'),2)
+ 		$(error "Building with MSys is no longer supported")

--- a/tarballpatches/configure.ac.patch
+++ b/tarballpatches/configure.ac.patch
@@ -1,0 +1,14 @@
+diff --git a/configure.ac b/configure.ac
+index 38ff866..c9cf5ac 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -463,6 +463,9 @@ else
+             CC_LD_DYNPATH=-Wl,+b,
+           else
+              CC_LD_DYNPATH=
++             if test "$(uname -s)" = "OS/390"; then
++                CC_LD_DYNPATH=-L
++             fi
+              AC_MSG_WARN([linker does not support runtime path to dynamic libraries])
+           fi
+       fi

--- a/tarballpatches/configure.patch
+++ b/tarballpatches/configure.patch
@@ -1,0 +1,635 @@
+diff --git a/configure b/configure
+index 98a208d..268001b 100755
+--- a/configure
++++ b/configure
+@@ -1515,7 +1515,7 @@ fi
+ ac_fn_c_try_compile ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  rm -f conftest.$ac_objext conftest.beam
++  rm -f conftest.$ac_objext conftest.dbg conftest.beam
+   if { { ac_try="$ac_compile"
+ case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -1594,9 +1594,9 @@ then :
+ else $as_nop
+   eval "$3=yes"
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+ eval ac_res=\$$3
+ 	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+@@ -1629,7 +1629,7 @@ then :
+ else $as_nop
+   eval "$3=no"
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+ eval ac_res=\$$3
+ 	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+@@ -1644,7 +1644,7 @@ printf "%s\n" "$ac_res" >&6; }
+ ac_fn_c_try_link ()
+ {
+   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  rm -f conftest.$ac_objext conftest.beam conftest$ac_exeext
++  rm -f conftest.$ac_objext conftest.dbg conftest.beam conftest$ac_exeext
+   if { { ac_try="$ac_link"
+ case "(($ac_try" in
+   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+@@ -1679,7 +1679,7 @@ fi
+   # created by the PGI compiler (conftest_ipa8_conftest.oo), as it would
+   # interfere with the next link command; also delete a directory that is
+   # left behind by Apple's compiler.  We do this before executing the actions.
+-  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
++  rm -rf conftest.dSYM conftest_ipa8_conftest.oo conftest.dbg
+   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+   as_fn_set_status $ac_retval
+ 
+@@ -1722,7 +1722,7 @@ sed 's/^/| /' conftest.$ac_ext >&5
+ 
+        ac_retval=$ac_status
+ fi
+-  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
++  rm -rf conftest.dSYM conftest_ipa8_conftest.oo conftest.dbg
+   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+   as_fn_set_status $ac_retval
+ 
+@@ -1780,7 +1780,7 @@ then :
+ else $as_nop
+   eval "$3=no"
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ fi
+ eval ac_res=\$$3
+@@ -1839,9 +1839,9 @@ then :
+ else $as_nop
+   eval "$4=no"
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+ eval ac_res=\$$4
+ 	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+@@ -2110,7 +2110,7 @@ printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;}
+     rm -f -r conftest* confdefs* conf$$* $ac_clean_files &&
+     exit $exit_status
+ ' 0
+-for ac_signal in 1 2 13 15; do
++for ac_signal in HUP INT PIPE TERM; do
+   trap 'ac_signal='$ac_signal'; as_fn_exit 1' $ac_signal
+ done
+ ac_signal=0
+@@ -3448,7 +3448,7 @@ fi
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $cross_compiling" >&5
+ printf "%s\n" "$cross_compiling" >&6; }
+ 
+-rm -f conftest.$ac_ext conftest$ac_cv_exeext conftest.out
++rm -f conftest.$ac_ext conftest$ac_cv_exeext conftest.out conftest.o
+ ac_clean_files=$ac_clean_files_save
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
+ printf %s "checking for suffix of object files... " >&6; }
+@@ -3529,7 +3529,7 @@ then :
+ else $as_nop
+   ac_compiler_gnu=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ ac_cv_c_compiler_gnu=$ac_compiler_gnu
+ 
+ fi
+@@ -3602,11 +3602,11 @@ if ac_fn_c_try_compile "$LINENO"
+ then :
+   ac_cv_prog_cc_g=yes
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+    ac_c_werror_flag=$ac_save_c_werror_flag
+ fi
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
+@@ -3648,7 +3648,7 @@ do
+ then :
+   ac_cv_prog_cc_c11=$ac_arg
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam
+   test "x$ac_cv_prog_cc_c11" != "xno" && break
+ done
+ rm -f conftest.$ac_ext
+@@ -3694,7 +3694,7 @@ do
+ then :
+   ac_cv_prog_cc_c99=$ac_arg
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam
+   test "x$ac_cv_prog_cc_c99" != "xno" && break
+ done
+ rm -f conftest.$ac_ext
+@@ -3740,7 +3740,7 @@ do
+ then :
+   ac_cv_prog_cc_c89=$ac_arg
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam
+   test "x$ac_cv_prog_cc_c89" != "xno" && break
+ done
+ rm -f conftest.$ac_ext
+@@ -3838,7 +3838,7 @@ then :
+ else $as_nop
+   ac_cv_working_alloca_h=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ fi
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_working_alloca_h" >&5
+@@ -3891,7 +3891,7 @@ then :
+ else $as_nop
+   ac_cv_func_alloca_works=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ fi
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_alloca_works" >&5
+@@ -3950,7 +3950,7 @@ else $as_nop
+   ac_cv_c_stack_direction=-1
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
++  conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+ 
+ fi
+@@ -4480,7 +4480,7 @@ then :
+ else $as_nop
+   ac_compiler_gnu=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ ac_cv_c_compiler_gnu=$ac_compiler_gnu
+ 
+ fi
+@@ -4553,11 +4553,11 @@ if ac_fn_c_try_compile "$LINENO"
+ then :
+   ac_cv_prog_cc_g=yes
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+    ac_c_werror_flag=$ac_save_c_werror_flag
+ fi
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
+@@ -4599,7 +4599,7 @@ do
+ then :
+   ac_cv_prog_cc_c11=$ac_arg
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam
+   test "x$ac_cv_prog_cc_c11" != "xno" && break
+ done
+ rm -f conftest.$ac_ext
+@@ -4645,7 +4645,7 @@ do
+ then :
+   ac_cv_prog_cc_c99=$ac_arg
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam
+   test "x$ac_cv_prog_cc_c99" != "xno" && break
+ done
+ rm -f conftest.$ac_ext
+@@ -4691,7 +4691,7 @@ do
+ then :
+   ac_cv_prog_cc_c89=$ac_arg
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam
+   test "x$ac_cv_prog_cc_c89" != "xno" && break
+ done
+ rm -f conftest.$ac_ext
+@@ -4744,7 +4744,7 @@ if ac_fn_c_try_compile "$LINENO"
+ then :
+   ac_cv_c_inline=$ac_kw
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+   test "$ac_cv_c_inline" != no && break
+ done
+ 
+@@ -4801,7 +4801,7 @@ then :
+ else $as_nop
+   git_cv_ld_dashr=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+    LDFLAGS="${SAVE_LDFLAGS}"
+ 
+@@ -4837,7 +4837,7 @@ then :
+ else $as_nop
+   git_cv_ld_wl_rpath=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+       LDFLAGS="${SAVE_LDFLAGS}"
+ 
+@@ -4873,7 +4873,7 @@ then :
+ else $as_nop
+   git_cv_ld_rpath=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+          LDFLAGS="${SAVE_LDFLAGS}"
+ 
+@@ -4909,7 +4909,7 @@ then :
+ else $as_nop
+   git_cv_ld_wl_b=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+             LDFLAGS="${SAVE_LDFLAGS}"
+ 
+@@ -4920,6 +4920,9 @@ printf "%s\n" "$git_cv_ld_wl_b" >&6; }
+             CC_LD_DYNPATH=-Wl,+b,
+           else
+              CC_LD_DYNPATH=
++            if test "$host" == "openedition"; then
++             CC_LD_DYNPATH=-L
++            fi 
+              { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: linker does not support runtime path to dynamic libraries" >&5
+ printf "%s\n" "$as_me: WARNING: linker does not support runtime path to dynamic libraries" >&2;}
+           fi
+@@ -5306,7 +5309,7 @@ then :
+ else $as_nop
+   ac_cv_lib_crypto_SHA1_Init=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -5345,7 +5348,7 @@ then :
+ else $as_nop
+   ac_cv_lib_ssl_SHA1_Init=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -5417,7 +5420,7 @@ then :
+ else $as_nop
+   ac_cv_lib_pcre2_8_pcre2_config_8=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -5486,7 +5489,7 @@ then :
+ else $as_nop
+   ac_cv_lib_curl_curl_global_init=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -5616,7 +5619,7 @@ then :
+ else $as_nop
+   ac_cv_lib_expat_XML_ParserCreate=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -5698,7 +5701,7 @@ else $as_nop
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+     LIBS="$old_LIBS"
+ done
+@@ -5762,7 +5765,7 @@ else $as_nop
+ printf "%s\n" "no" >&6; }
+ 	NO_DEFLATE_BOUND=yes
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS="$old_LIBS"
+ 
+@@ -5808,7 +5811,7 @@ then :
+ else $as_nop
+   ac_cv_lib_c_socket=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -5868,7 +5871,7 @@ then :
+ else $as_nop
+   ac_cv_lib_resolv_inet_ntop=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -5924,7 +5927,7 @@ then :
+ else $as_nop
+   ac_cv_lib_resolv_inet_pton=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -5980,7 +5983,7 @@ then :
+ else $as_nop
+   ac_cv_lib_resolv_hstrerror=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -6035,7 +6038,7 @@ then :
+ else $as_nop
+   ac_cv_lib_c_basename=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -6082,7 +6085,7 @@ else $as_nop
+ printf "%s\n" "no" >&6; }
+ 	LIBC_CONTAINS_LIBINTL=
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+ config_appended_defs="$config_appended_defs${newline}LIBC_CONTAINS_LIBINTL=${LIBC_CONTAINS_LIBINTL}"
+@@ -6201,7 +6204,7 @@ printf "%s\n" "yes" >&6; }
+ 
+ 	OLD_ICONV=UnfortunatelyYes
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ 
+ 
+ if test -n "$ICONVDIR"; then
+@@ -6274,7 +6277,7 @@ else $as_nop
+   ac_cv_iconv_omits_bom=yes
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
++  conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+ 
+ 
+@@ -6343,7 +6346,7 @@ then :
+                   break 2
+ 
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+             done
+          done
+ 
+@@ -6503,7 +6506,7 @@ do
+ then :
+   ac_cv_search_getaddrinfo=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_getaddrinfo+y}
+ then :
+@@ -6900,7 +6903,7 @@ else $as_nop
+   ac_cv_fread_reads_directories=yes
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
++  conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+ 
+ 
+@@ -6965,7 +6968,7 @@ else $as_nop
+   ac_cv_snprintf_returns_bogus=yes
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
++  conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ fi
+ 
+ 
+@@ -7112,7 +7115,7 @@ then :
+ else $as_nop
+   ac_cv_lib_iconv_locale_charset=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -7151,7 +7154,7 @@ then :
+ else $as_nop
+   ac_cv_lib_charset_locale_charset=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -7206,7 +7209,7 @@ do
+ then :
+   ac_cv_search_clock_gettime=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_clock_gettime+y}
+ then :
+@@ -7272,7 +7275,7 @@ else $as_nop
+ printf "%s\n" "no" >&6; }
+ 	HAVE_CLOCK_MONOTONIC=
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ 
+ config_appended_defs="$config_appended_defs${newline}HAVE_CLOCK_MONOTONIC=${HAVE_CLOCK_MONOTONIC}"
+ 
+@@ -7316,7 +7319,7 @@ do
+ then :
+   ac_cv_search_sync_file_range=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_sync_file_range+y}
+ then :
+@@ -7391,7 +7394,7 @@ do
+ then :
+   ac_cv_search_setitimer=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_setitimer+y}
+ then :
+@@ -7465,7 +7468,7 @@ do
+ then :
+   ac_cv_search_strcasestr=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_strcasestr+y}
+ then :
+@@ -7539,7 +7542,7 @@ do
+ then :
+   ac_cv_search_memmem=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_memmem+y}
+ then :
+@@ -7613,7 +7616,7 @@ do
+ then :
+   ac_cv_search_strlcpy=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_strlcpy+y}
+ then :
+@@ -7702,7 +7705,7 @@ do
+ then :
+   ac_cv_search_strtoumax=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_strtoumax+y}
+ then :
+@@ -7776,7 +7779,7 @@ do
+ then :
+   ac_cv_search_setenv=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_setenv+y}
+ then :
+@@ -7850,7 +7853,7 @@ do
+ then :
+   ac_cv_search_unsetenv=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_unsetenv+y}
+ then :
+@@ -7924,7 +7927,7 @@ do
+ then :
+   ac_cv_search_mkdtemp=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_mkdtemp+y}
+ then :
+@@ -7998,7 +8001,7 @@ do
+ then :
+   ac_cv_search_initgroups=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_initgroups+y}
+ then :
+@@ -8072,7 +8075,7 @@ do
+ then :
+   ac_cv_search_getdelim=$ac_res
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext
+   if test ${ac_cv_search_getdelim+y}
+ then :
+@@ -8151,7 +8154,7 @@ else $as_nop
+ printf "%s\n" "no" >&6; }
+ 	HAVE_BSD_SYSCTL=
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam conftest.$ac_ext
+ 
+ config_appended_defs="$config_appended_defs${newline}HAVE_BSD_SYSCTL=${HAVE_BSD_SYSCTL}"
+ 
+@@ -8237,7 +8240,7 @@ else $as_nop
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+       CFLAGS="$old_CFLAGS"
+       LIBS="$old_LIBS"
+@@ -8272,7 +8275,7 @@ then :
+ else $as_nop
+   ac_cv_lib_pthread_pthread_create=no
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ LIBS=$ac_check_lib_save_LIBS
+ fi
+@@ -8330,7 +8333,7 @@ else $as_nop
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+ fi
+-rm -f core conftest.err conftest.$ac_objext conftest.beam \
++rm -f core conftest.err conftest.$ac_objext conftest.dbg conftest.beam \
+     conftest$ac_exeext conftest.$ac_ext
+ 
+   CFLAGS="$old_CFLAGS"
+@@ -9088,7 +9091,7 @@ $debug ||
+   : "${ac_tmp:=$tmp}"
+   { test ! -d "$ac_tmp" || rm -fr "$ac_tmp"; } && exit $exit_status
+ ' 0
+-  trap 'as_fn_exit 1' 1 2 13 15
++  trap 'as_fn_exit 1' HUP INT PIPE TERM
+ }
+ # Create a (secure) tmp directory for tmp files.
+ 

--- a/tarballpatches/convert.c.patch
+++ b/tarballpatches/convert.c.patch
@@ -1,5 +1,5 @@
 diff --git a/convert.c b/convert.c
-index 95e6a52..eba9a48 100644
+index a54d169..28f0a3b 100644
 --- a/convert.c
 +++ b/convert.c
 @@ -370,12 +370,15 @@ static int check_roundtrip(const char *enc_name)
@@ -47,9 +47,9 @@ index 95e6a52..eba9a48 100644
  	/*
  	 * No encoding is specified or there is nothing to encode.
  	 * Tell the caller that the content was not modified.
-@@ -1293,20 +1304,38 @@ static int git_path_check_ident(struct attr_check_item *check)
- 	return !!ATTR_TRUE(value);
- }
+@@ -1295,18 +1306,36 @@ static int git_path_check_ident(struct attr_check_item *check)
+ 
+ static struct attr_check *check;
  
 +static const char* get_platform() {
 +	struct utsname uname_info;
@@ -64,16 +64,14 @@ index 95e6a52..eba9a48 100644
 +  return uname_info.sysname;
 +}
 +
-+
- static struct attr_check *check;
- 
  void convert_attrs(struct index_state *istate,
  		   struct conv_attrs *ca, const char *path)
  {
  	struct attr_check_item *ccheck = NULL;
-+	struct strbuf platform_working_tree_encoding = STRBUF_INIT;
-+
++  struct strbuf platform_working_tree_encoding = STRBUF_INIT; 
++  
 +	strbuf_addf(&platform_working_tree_encoding, "%s-working-tree-encoding", get_platform());
++
  
  	if (!check) {
  		check = attr_check_initl("crlf", "ident", "filter",
@@ -85,7 +83,7 @@ index 95e6a52..eba9a48 100644
  	}
 +	strbuf_release(&platform_working_tree_encoding);
  
- 	git_check_attr(istate, path, check);
+ 	git_check_attr(istate, NULL, path, check);
  	ccheck = check->items;
 @@ -1327,6 +1356,8 @@ void convert_attrs(struct index_state *istate,
  			ca->crlf_action = CRLF_TEXT_CRLF;

--- a/tarballpatches/object-file.c.patch
+++ b/tarballpatches/object-file.c.patch
@@ -1,5 +1,5 @@
 diff --git a/object-file.c b/object-file.c
-index 2629055..aa5bac0 100644
+index 939865c..ae92aaa 100644
 --- a/object-file.c
 +++ b/object-file.c
 @@ -8,6 +8,7 @@
@@ -10,9 +10,9 @@ index 2629055..aa5bac0 100644
  #include "string-list.h"
  #include "lockfile.h"
  #include "delta.h"
-@@ -34,6 +35,10 @@
- #include "promisor-remote.h"
+@@ -35,6 +36,10 @@
  #include "submodule.h"
+ #include "fsck.h"
  
 +#ifdef __MVS__
 +#include <_Ccsid.h>
@@ -21,7 +21,7 @@ index 2629055..aa5bac0 100644
  /* The maximum size for an object header. */
  #define MAX_HEADER_LEN 32
  
-@@ -2500,18 +2505,86 @@ int index_fd(struct index_state *istate, struct object_id *oid,
+@@ -2463,18 +2468,86 @@ int index_fd(struct index_state *istate, struct object_id *oid,
  	return ret;
  }
  

--- a/tarballpatches/object-file.c.patch
+++ b/tarballpatches/object-file.c.patch
@@ -1,5 +1,5 @@
 diff --git a/object-file.c b/object-file.c
-index 5b270f0..9aefc37 100644
+index 2629055..aa5bac0 100644
 --- a/object-file.c
 +++ b/object-file.c
 @@ -8,6 +8,7 @@
@@ -21,12 +21,12 @@ index 5b270f0..9aefc37 100644
  /* The maximum size for an object header. */
  #define MAX_HEADER_LEN 32
  
-@@ -2499,18 +2504,86 @@ int index_fd(struct index_state *istate, struct object_id *oid,
+@@ -2500,18 +2505,86 @@ int index_fd(struct index_state *istate, struct object_id *oid,
  	return ret;
  }
  
 +#ifdef __MVS__
-+int validate_codeset(struct index_state *istate, const char *path, int* autoconvertToASCII) {
++void validate_codeset(struct index_state *istate, const char *path, int* autoconvertToASCII) {
 +	struct conv_attrs ca;
 +  struct stat st;
 +  unsigned short attr_ccsid;


### PR DESCRIPTION
The CC_LD_DYNPATH is a bit of a hack because if CC_LD_DYNPATH is set to null, then the directory is added to the link step, leading to a linker error when a dir is specified. This linker error does not occur with xlclang when a dir is specified. It does occur with clang on other platforms though, but the other platforms do not have CC_LD_DYNPATH set to null.

In addition, clang is a bit more strict, so validate_codeset had to be changed to a void return type since the returns return no value.