### PR TITLE
fix for adding utf-8 tagged file to default working-tree-encoding

### DIFF
--- a/tarballpatches/object-file.c.patch
+++ b/tarballpatches/object-file.c.patch
@@ -1,5 +1,5 @@
 diff --git a/object-file.c b/object-file.c
-index 939865c..ae92aaa 100644
+index 939865c..bfd1b1f 100644
 --- a/object-file.c
 +++ b/object-file.c
 @@ -8,6 +8,7 @@
@@ -21,7 +21,7 @@ index 939865c..ae92aaa 100644
  /* The maximum size for an object header. */
  #define MAX_HEADER_LEN 32
  
-@@ -2463,18 +2468,86 @@ int index_fd(struct index_state *istate, struct object_id *oid,
+@@ -2463,18 +2468,87 @@ int index_fd(struct index_state *istate, struct object_id *oid,
  	return ret;
  }
  
@@ -60,7 +60,8 @@ index 939865c..ae92aaa 100644
 +      *autoconvertToASCII = 1;
 +      return;
 +    }
-+    if (file_ccsid == 819 && attr_ccsid == 1208) {
++    // Allow tag mixing of 819 and 1208
++    if ((file_ccsid == 819 || file_ccsid == 1208) && (attr_ccsid == 1208 || attr_ccsid == 819)) {
 +      return;
 +    }
 +    // Don't check for binary files, just add them


### PR DESCRIPTION
This is a fix for https://github.com/ZOSOpenTools/gitport/issues/61