### PR TITLE
Add ability allowing bump to manage version

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -3,6 +3,7 @@
 #
 export ZOPEN_TYPE="TARBALL"
 
+# bump: git-version /GIT_VERSION="(.*)"/ https://github.com/git/git.git|*
 GIT_VERSION="2.41.0"
 
 export ZOPEN_GIT_URL="https://github.com/git/git"


### PR DESCRIPTION
```shell
$ bump -v check buildenv
buildenv:7: git 2.41.0 -> 2.41.0 1.097s
```

Manually set buildenv back to 2.40.0 to check.

```shell
$ git diff buildenv 
───────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ STDIN
───────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ diff --git a/buildenv b/buildenv
   2   │ index 0b60d63..c61d49c 100644
   3   │ --- a/buildenv
   4   │ +++ b/buildenv
   5   │ @@ -4,7 +4,7 @@
   6   │  export ZOPEN_TYPE="TARBALL"
   7   │  
   8   │  # bump: git /GIT_VERSION="(.*)"/ https://github.com/git/git.git|*
   9   │ -GIT_VERSION="2.41.0"
  10   │ +GIT_VERSION="2.40.0"
  11   │  

$ bump -v check buildenv 
buildenv:7: git 2.40.0 -> 2.41.0 1.136s

$ bump diff buildenv | bat
───────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ STDIN
───────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ --- buildenv
   2   │ +++ buildenv
   3   │ @@ -4,7 +4,7 @@
   4   │  export ZOPEN_TYPE="TARBALL"
   5   │  
   6   │  # bump: git /GIT_VERSION="(.*)"/ https://github.com/git/git.git|*
   7   │ -GIT_VERSION="2.40.0"
   8   │ +GIT_VERSION="2.41.0"
   9   │  

```


We can either pull all repos down, and allow bump to send updates to them, or centralise URLs to meta, so that bump can do this via CI on that one repo (meta).
Then, *port can first refer to a system's meta for URLs (implying that every install of meta needs to periodically pull updates to a versions file... much like we have zopen update-cacert).