### PR TITLE
Add a post install check to validate that git can clone https/git protocol

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -174,6 +174,15 @@ GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
 EOF
 }
 
+zopen_post_install() {
+  installdir=$1
+  # Validate that git clone work for https and git protocols
+  set -e
+  $1/bin/git clone https://github.com/ZOSOpenTools/gitport.git httpgitport
+  $1/bin/git clone git@github.com:ZOSOpenTools/gitport.git gitport
+  set +e
+}
+
 zopen_get_version() {
   ./git --version | awk -F" " '{print $3}'
 }


### PR DESCRIPTION
Uses set -e to exit if there's an error