### PR TITLE
Create bump.yml

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,16 @@
+name: 'Automatic version updates'
+
+on:
+  schedule:
+    # minute hour dom month dow (UTC)
+    - cron: '00 15 * * *'
+  # enable manual trigger of version updates
+  workflow_dispatch:
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: ZOSOpenTools/meta/actions@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.BUMP_TOKEN }}


### PR DESCRIPTION
Same as in duckdb.
There's an option to create an org-wide secret - https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-organization

Once that's created (could you, please), I'll add a commit to this PR to refer to that in line 16 instead.
Still have to figure that last part out though...