### PR TITLE
Fix regression in git

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -97,16 +97,6 @@ expectedFailures:3
 ZZ
 }
 
-zopen_append_to_env() {
-cat <<EOF
-unset GIT_MAN_PATH
-unset GIT_ROOT
-unset GIT_SHELL
-export GIT_TEMPLATE_DIR="\$PWD/share/git-core/templates"
-export GIT_EXEC_PATH="\$PWD/libexec/git-core/"
-EOF
-}
-
 zopen_post_install()
 {
   # Validate that git clone work for https and git protocols
@@ -158,15 +148,10 @@ cat <<EOF
 GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
 GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
 GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
+ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
 EOF
 }
 
 zopen_get_version() {
   ./git --version | awk -F" " '{print $3}'
-}
-
-zopen_append_to_zoslib_env() {
- cat <<EOF
-ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
-EOF
 }


### PR DESCRIPTION
Fix regression because of duplicate `zopen_append_to_zoslib_env` entries.

Also remove no longer necessary environment variables.