### PR TITLE
Ensure certain GIT_ environment variables are always set

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -145,8 +145,8 @@ zopen_post_install()
 
 zopen_append_to_zoslib_env() {
 cat <<EOF
-GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
-GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
+GIT_TEMPLATE_DIR|overrideset|PROJECT_ROOT/share/git-core/templates
+GIT_EXEC_PATH|overrideset|PROJECT_ROOT/libexec/git-core
 GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
 ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
 EOF


### PR DESCRIPTION
* Don't overrideset GIT_SSL_CAINFO as that is should be configurable.
* Also don't do it for ASCII_TERMINFO as if it's a manual installation, it may point to the wrong path and we want the user to be able to set it