### PR TITLE
Revert back to set instead of overrideset for  GIT_TEMPLATE_DIR and GIT_EXEC_PATH

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -145,8 +145,8 @@ zopen_post_install()
 
 zopen_append_to_zoslib_env() {
 cat <<EOF
-GIT_TEMPLATE_DIR|overrideset|PROJECT_ROOT/share/git-core/templates
-GIT_EXEC_PATH|overrideset|PROJECT_ROOT/libexec/git-core
+GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
+GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
 GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
 ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
 EOF

--- a/buildenv
+++ b/buildenv
@@ -7,10 +7,10 @@ export ZOPEN_BUILD_LINE="STABLE"
 GIT_VERSION="2.41.0"
 
 export ZOPEN_DEV_URL="https://github.com/git/git"
-export ZOPEN_DEV_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext coreutils diffutils bash"
+export ZOPEN_DEV_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext coreutils diffutils bash gettext"
 
 export ZOPEN_STABLE_URL="https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz"
-export ZOPEN_STABLE_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext gzip tar coreutils zoslib diffutils ncurses bash sed libpcre2"
+export ZOPEN_STABLE_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext gzip tar coreutils zoslib diffutils ncurses bash sed libpcre2 gettext"
 
 #
 # Note the 'man' tarball release is numbered independently from the 'git' release.

--- a/buildenv
+++ b/buildenv
@@ -7,10 +7,10 @@ export ZOPEN_BUILD_LINE="STABLE"
 GIT_VERSION="2.41.0"
 
 export ZOPEN_DEV_URL="https://github.com/git/git"
-export ZOPEN_DEV_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext coreutils diffutils bash gettext"
+export ZOPEN_DEV_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext coreutils diffutils bash"
 
 export ZOPEN_STABLE_URL="https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz"
-export ZOPEN_STABLE_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext gzip tar coreutils zoslib diffutils ncurses bash sed libpcre2 gettext"
+export ZOPEN_STABLE_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext gzip tar coreutils zoslib diffutils ncurses bash sed libpcre2"
 
 #
 # Note the 'man' tarball release is numbered independently from the 'git' release.


### PR DESCRIPTION
CW witnessed the following issue:
```
 /home/opnzos/zopen-20231021/usr/local/zopen/git/git-2.41.0.20231020_134608.zos/libexec/git-core/git-sh-setup: line 46: /home/opnzos/zopen-20231021/usr/local/zopen/git/git-2.41.0.20231020_134608.zos/libexec/libexec/git-core/git-sh-i18n: EDC5129I No such file or directory.
/home/opnzos/zopen-20231021/usr/local/zopen/git/git-2.41.0.20231020_134608.zos/libexec/git-core/git-sh-setup: line 84: eval_gettext: command not found
```
The issue is that it calls a git under /home/opnzos/zopen-20231021/usr/local/zopen/git/git-2.41.0.20231020_134608.zos/libexec/git-core/git (not in bin) and this determined libexec is wrong. 

We'll need to rely on set for now. That means that when git is run, it sets GIT_EXEC_PATH, and then calls its libexec tool, but passes down the GIT_EXEC_PATH path.