### PR TITLE
Add support to modify tag for utf8 encoded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,33 @@ When adding files, you need to make sure that the z/OS file tag matches the work
 
 ### Encodings and z/OS File Tags (ccsids)
 
-Git on z/OS will do its best to associate a file tag (ccsid) with the git working-tree-encoding. However, UTF-8 encoded files are by default
-tagged as IS08859-1 because z/OS Open Tools currently acts on _BPXK_AUTOCVT=ON. To modify the default uf8 tag, you can do as follows:
+Git on z/OS will do its best to associate a file tag (ccsid) with the git working-tree-encoding. However, there is a special case for 
+UTF-8 encoded files. Such files are tagged as IS08859-1 (ccsid 819) because z/OS Open Tools currently acts on _BPXK_AUTOCVT=ON, which does
+not auto-convert files tagged with the UTF-8 tag (ccsid 1208).
+
+The default UTF-8 tag is UTF8 (or ccsid 1208).
+
+To modify the default UTF-8 tag, you can either set the git config setting `core.utf8ccsid` to 1208 as follows:
 
 * `git config --global core.utf8ccsid 1208` # Global setting, 1208 is the ccsid for the UTF8 file tag
-* `git config core.utf8ccsid 1208` # Repo setting
+* `git config core.utf8ccsid 1208` # Local setting affecting the current repository
+
+Or you can set the GIT_UTF8_CCSID environment variable as follows:
+
 * `export GIT_UTF8_CCSID=1208` # environment variable
 
 The environment variable has precedence over the git config setting.
+
+#### Example
+Assuming you want to clone UTF-8 encoded files with the tag UTF8 or ccsid 1208 as opposed to the default ccsid (819):
+
+```
+git config --global core.utf8ccsid 1208 # Set the UTF-8 ccsid 1208 globally
+git clone https://github.com/git/git
+cd git
+ls -lT # you will notice that all files are now tagged as UTF-8
+```
+
 
 ### Binary files
 To specify a binary encoding, you can use the binary attribute as follows:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ To find out all of the supported encodings by git, run `iconv -l`.
 
 When adding files, you need to make sure that the z/OS file tag matches the working-tree-encoding. Otherwise, you may encounter an error.
 
+### Encodings and z/OS File Tags (ccsids)
+
+Git on z/OS will do its best to associate a file tag (ccsid) with the git working-tree-encoding. However, UTF-8 encoded files are by default
+tagged as IS08859-1 because z/OS Open Tools currently acts on _BPXK_AUTOCVT=ON. To modify the default uf8 tag, you can do as follows:
+
+* `git config --global core.utf8ccsid 1208` # Global setting, 1208 is the ccsid for the UTF8 file tag
+* `git config core.utf8ccsid 1208` # Repo setting
+* `export GIT_UTF8_CCSID=1208` # environment variable
+
+The environment variable has precedence over the git config setting.
+
 ### Binary files
 To specify a binary encoding, you can use the binary attribute as follows:
 ```

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Git on z/OS will do its best to associate a file tag (ccsid) with the git workin
 UTF-8 encoded files. Such files are tagged as IS08859-1 (ccsid 819) because z/OS Open Tools currently acts on _BPXK_AUTOCVT=ON, which does
 not auto-convert files tagged with the UTF-8 tag (ccsid 1208).
 
-The default UTF-8 tag is UTF8 (or ccsid 1208).
+Therefore, the default UTF-8 tag is IS08859-1 (or ccsid 819).
 
-To modify the default UTF-8 tag, you can either set the git config setting `core.utf8ccsid` to 1208 as follows:
+To modify the default UTF-8 tag, you can set the git config setting `core.utf8ccsid` to 1208 as follows:
 
 * `git config --global core.utf8ccsid 1208` # Global setting, 1208 is the ccsid for the UTF8 file tag
 * `git config core.utf8ccsid 1208` # Local setting affecting the current repository

--- a/stable-patches/config.c.patch
+++ b/stable-patches/config.c.patch
@@ -1,5 +1,5 @@
 diff --git a/config.c b/config.c
-index 3846a37..4cb3e7c 100644
+index 3846a37..dfd22ed 100644
 --- a/config.c
 +++ b/config.c
 @@ -39,6 +39,9 @@
@@ -12,13 +12,18 @@ index 3846a37..4cb3e7c 100644
  
  struct config_source {
  	struct config_source *prev;
-@@ -1670,6 +1673,13 @@ static int git_default_core_config(const char *var, const char *value,
+@@ -1670,6 +1673,18 @@ static int git_default_core_config(const char *var, const char *value,
  		return 0;
  	}
  
 + #ifdef __MVS__
 +	if (!strcmp(var, "core.ignorefiletags")) {
 +		ignore_file_tags = git_config_bool(var, value);
++		return 0;
++	}
++
++	if (!strcmp(var, "core.utf8ccsid")) {
++		utf8_ccsid = git_config_ulong(var, value, ctx->kvi);
 +		return 0;
 +	}
 +#endif

--- a/stable-patches/convert.c.patch
+++ b/stable-patches/convert.c.patch
@@ -1,5 +1,5 @@
 diff --git a/convert.c b/convert.c
-index 9ee79fe..a955084 100644
+index a8870ba..8e5c6fa 100644
 --- a/convert.c
 +++ b/convert.c
 @@ -377,12 +377,15 @@ static int check_roundtrip(const char *enc_name)

--- a/stable-patches/entry.c.patch
+++ b/stable-patches/entry.c.patch
@@ -1,8 +1,8 @@
 diff --git a/entry.c b/entry.c
-index 616e4f0..3fdca74 100644
+index 43767f9..3f3f8cb 100644
 --- a/entry.c
 +++ b/entry.c
-@@ -119,6 +119,24 @@ int fstat_checkout_output(int fd, const struct checkout *state, struct stat *st)
+@@ -126,6 +126,24 @@ int fstat_checkout_output(int fd, const struct checkout *state, struct stat *st)
  	return 0;
  }
  
@@ -14,7 +14,7 @@ index 616e4f0..3fdca74 100644
 +    if (ca.working_tree_encoding)
 +      __chgfdcodeset(fd, ca.working_tree_encoding); 
 +    else
-+      __setfdtext(fd);
++      __chgfdccsid(fd, utf8_ccsid);
 +  }
 +  else {
 +    __setfdbinary(fd);
@@ -27,7 +27,7 @@ index 616e4f0..3fdca74 100644
  static int streaming_write_entry(const struct cache_entry *ce, char *path,
  				 struct stream_filter *filter,
  				 const struct checkout *state, int to_tempfile,
-@@ -131,6 +149,10 @@ static int streaming_write_entry(const struct cache_entry *ce, char *path,
+@@ -138,6 +156,10 @@ static int streaming_write_entry(const struct cache_entry *ce, char *path,
  	if (fd < 0)
  		return -1;
  
@@ -38,7 +38,7 @@ index 616e4f0..3fdca74 100644
  	result |= stream_blob_to_fd(fd, &ce->oid, filter, 1);
  	*fstat_done = fstat_checkout_output(fd, state, statbuf);
  	result |= close(fd);
-@@ -367,6 +389,10 @@ static int write_entry(struct cache_entry *ce, char *path, struct conv_attrs *ca
+@@ -374,6 +396,10 @@ static int write_entry(struct cache_entry *ce, char *path, struct conv_attrs *ca
  			return error_errno("unable to create file %s", path);
  		}
  
@@ -49,3 +49,29 @@ index 616e4f0..3fdca74 100644
  		wrote = write_in_full(fd, new_blob, size);
  		if (!to_tempfile)
  			fstat_done = fstat_checkout_output(fd, state, &st);
+@@ -476,6 +502,25 @@ int checkout_entry_ca(struct cache_entry *ce, struct conv_attrs *ca,
+ 	struct stat st;
+ 	struct conv_attrs ca_buf;
+ 
++
++#ifdef __MVS__
++  const char* git_utf8_ccsid_str = getenv("GIT_UTF8_CCSID");
++
++  if (git_utf8_ccsid_str != NULL) {
++      char* endptr;
++      errno = 0;
++      long conv = strtol(git_utf8_ccsid_str, &endptr, 10);
++
++      if (!conv) {
++          perror("Error converting GIT_UTF8_CCSID to short");
++      } else if (endptr == git_utf8_ccsid_str) {
++          fprintf(stderr, "No digits were found in GIT_UTF8_CCSID\n");
++      } else {
++          utf8_ccsid = conv;
++      }
++  }
++#endif
++
+ 	if (ce->ce_flags & CE_WT_REMOVE) {
+ 		if (topath)
+ 			/*

--- a/stable-patches/environment.c.patch
+++ b/stable-patches/environment.c.patch
@@ -1,13 +1,14 @@
 diff --git a/environment.c b/environment.c
-index 18d042b..b268cd3 100644
+index f98d76f..8887562 100644
 --- a/environment.c
 +++ b/environment.c
-@@ -43,6 +43,9 @@ const char *git_hooks_path;
+@@ -51,6 +51,10 @@ const char *git_hooks_path;
  int zlib_compression_level = Z_BEST_SPEED;
  int pack_compression_level = Z_DEFAULT_COMPRESSION;
  int fsync_object_files = -1;
 +#ifdef __MVS__
 +int ignore_file_tags = 0;
++int utf8_ccsid = 819;
 +#endif
  int use_fsync = -1;
  enum fsync_method fsync_method = FSYNC_METHOD_DEFAULT;

--- a/stable-patches/environment.h.patch
+++ b/stable-patches/environment.h.patch
@@ -1,0 +1,15 @@
+diff --git a/environment.h b/environment.h
+index c537747..0673680 100644
+--- a/environment.h
++++ b/environment.h
+@@ -133,6 +133,10 @@ extern size_t delta_base_cache_limit;
+ extern unsigned long big_file_threshold;
+ extern unsigned long pack_size_limit_cfg;
+ 
++#ifdef __MVS__
++extern int utf8_ccsid;
++#endif
++
+ /*
+  * Accessors for the core.sharedrepository config which lazy-load the value
+  * from the config (if not already set). The "reset" function can be

--- a/stable-patches/object-file.c.patch
+++ b/stable-patches/object-file.c.patch
@@ -1,5 +1,5 @@
 diff --git a/object-file.c b/object-file.c
-index 7dc0c4b..02ee8bd 100644
+index 7dc0c4b..c610c8d 100644
 --- a/object-file.c
 +++ b/object-file.c
 @@ -44,6 +44,11 @@
@@ -14,7 +14,7 @@ index 7dc0c4b..02ee8bd 100644
  /* The maximum size for an object header. */
  #define MAX_HEADER_LEN 32
  
-@@ -2478,18 +2483,87 @@ int index_fd(struct index_state *istate, struct object_id *oid,
+@@ -2478,18 +2483,88 @@ int index_fd(struct index_state *istate, struct object_id *oid,
  	return ret;
  }
  
@@ -36,8 +36,9 @@ index 7dc0c4b..02ee8bd 100644
 +  else if (ca.working_tree_encoding) {
 +    attr_ccsid = __toCcsid(ca.working_tree_encoding);
 +  }
-+  else
-+    attr_ccsid = 819;
++  else {
++    attr_ccsid = utf8_ccsid;
++  }
 +
 +  if (stat(path, &st) < 0)
 +    return;
@@ -49,8 +50,8 @@ index 7dc0c4b..02ee8bd 100644
 +  }
 +
 +  if (attr_ccsid != file_ccsid) {
-+    if (file_ccsid == 1047 && attr_ccsid == 819) {
-+autoconvertToASCII = 1;
++    if (file_ccsid == 1047 && (attr_ccsid == 819 || attr_ccsid == 1208)) {
++      autoconvertToASCII = 1;
 +      return;
 +    }
 +    // Allow tag mixing of 819 and 1208

--- a/stable-patches/object-file.c.patch
+++ b/stable-patches/object-file.c.patch
@@ -50,7 +50,7 @@ index 7dc0c4b..c610c8d 100644
 +  }
 +
 +  if (attr_ccsid != file_ccsid) {
-+    if (file_ccsid == 1047 && (attr_ccsid == 819 || attr_ccsid == 1208)) {
++    if (file_ccsid == 1047 && attr_ccsid == 819) {
 +      autoconvertToASCII = 1;
 +      return;
 +    }


### PR DESCRIPTION
### Problem:
Issue https://github.com/ZOSOpenTools/gitport/issues/96 reports a difference in behaviour between Rocket Software's Git and z/OS Open Tools' git. By default, Git encodes all files in UTF-8. This behaviour is equivalent between Rocket's git and zopen's git. 
However, the z/OS file tag (ccsid) is where Rocket's git and zopen's git differ. Rocket's git tags all UTF-8 encoded files as 1208 (UTF-8). If `_BPXK_AUTOCVT=ON` is in effect, files tagged as 1208 **will not be** auto-converted. They will be read as is. If `_BPXK_AUTOCVT=ALL` is in effect, 1208 tagged files **will be** auto-converted. Since z/OS Open Tools relies on `_BPXK_AUTOCVT=ON`, such files are tagged as ISO8859-1 (ccsid 819), which is a stand-in for UTF-8. This enables an EBCDIC program reading 819 tagged files as input to auto-convert into EBCDIC.

In the case of https://github.com/ZOSOpenTools/gitport/issues/96, the expectation is that there will be no auto-conversion. This is really a consequence of `_BPXK_AUTOCVT=ALL` not being set. If it were set, then the originator would have experienced the same issues as if the file were tagged as 819. 

However, in order to provide compatibility with Rocket Software, this PR will provide an environment variable and option to allow for the default UTF-8 tag (819) to be overridden.

### Git Background
When cloning a repository, Git on z/OS will do its best to associate a file tag (ccsid) with the git working-tree-encoding. There is a special case for UTF-8 encoded files. They are by default tagged as IS08859-1 because:
  * z/OS Open Tools are built in ASCII mode (819)
    * There is no auto-conversion from ISO8859-1 to an ASCII program (it's read as is), which is what we expect
    * If a file is tagged as UTF-8 and BPXK_AUTOCVT=ALL is specified, then the file will be auto-converted from UTF-8 to ASCII, which will result in data loss
      * Note: UTF8 tagged files are auto-converted with BPXK_AUTOCVT=ALL, and are not auto-converted when BPXK_AUTOCVT=ON which can lead to unexpected behaviour depending on which BPXK_AUTOCVT is set.
  *  So that means no auto-conversion occurs if BPXK_AUTOCVT=ON (fine for ASCII application, not good for EBCDIC application if you're expecting auto-conversion)
  * EBCDIC programs like /bin/cat will display garbled output on a UTF8 (1208) tagged file with BPXK_AUTOCVT=ON

### PR details
This PR enables support for changing the tag of UTF8 encoded files to enable compatibility with Rocket Software's Git.

Therefore, the default UTF-8 tag is IS08859-1 (or ccsid 819).

To modify the default uf8 tag, you can do as follows:

* `git config --global core.utf8ccsid 1208` # Global setting, 1208 is the ccsid for the UTF8 file tag
* `git config core.utf8ccsid 1208` # Local repo setting
* `export GIT_UTF8_CCSID=1208` # Environment variable

The environment variable takes precedence over the configuration settings.

### Example

Assume you want to clone UTF-8 encoded files with tag UTF8 or ccsid 1208 as opposed to the default ccsid.

```
git config --global core.utf8ccsid 1208 # Set the utf8 ccsid globally
git clone https://github.com/git/git
cd git
ls -lT # you will notice that all files are now tagged as UTF-8
```
