### PR TITLE
Fix for unset returning non-zero

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -148,6 +148,7 @@ zopen_append_to_env()
 cat <<ZZ
   unset GIT_TEMPLATE_DIR
   unset GIT_EXEC_PATH
+  true # unset may return non-zero, reset to 0
 ZZ
 }
 


### PR DESCRIPTION
If GIT_EXEC_PATH is not set, under /bin/sh it will return non-zero. This adds a true to reset the return code to zero