### PR TITLE
Avoid high memory footprint when adding files that require conversion

### DIFF
--- a/stable-patches/convert.c.patch
+++ b/stable-patches/convert.c.patch
@@ -1,8 +1,19 @@
 diff --git a/convert.c b/convert.c
-index a8870ba..8e5c6fa 100644
+index a8870ba..bd238ec 100644
 --- a/convert.c
 +++ b/convert.c
-@@ -377,12 +377,15 @@ static int check_roundtrip(const char *enc_name)
+@@ -322,6 +322,10 @@ static void trace_encoding(const char *context, const char *path,
+ 	struct strbuf trace = STRBUF_INIT;
+ 	int i;
+ 
++  // If tracing is not on, exit early to avoid high memory footprint
++	if (!trace_pass_fl(&coe)) {
++    return;
++  }
+ 	strbuf_addf(&trace, "%s (%s, considered %s):\n", context, path, encoding);
+ 	for (i = 0; i < len && buf; ++i) {
+ 		strbuf_addf(
+@@ -377,12 +381,15 @@ static int check_roundtrip(const char *enc_name)
  static const char *default_encoding = "UTF-8";
  
  static int encode_to_git(const char *path, const char *src, size_t src_len,
@@ -19,7 +30,7 @@ index a8870ba..8e5c6fa 100644
  	/*
  	 * No encoding is specified or there is nothing to encode.
  	 * Tell the caller that the content was not modified.
-@@ -403,6 +406,11 @@ static int encode_to_git(const char *path, const char *src, size_t src_len,
+@@ -403,6 +410,11 @@ static int encode_to_git(const char *path, const char *src, size_t src_len,
  		return 0;
  
  	trace_encoding("source", path, enc, src, src_len);
@@ -31,7 +42,7 @@ index a8870ba..8e5c6fa 100644
  	dst = reencode_string_len(src, src_len, default_encoding, enc,
  				  &dst_len);
  	if (!dst) {
-@@ -468,11 +476,14 @@ static int encode_to_git(const char *path, const char *src, size_t src_len,
+@@ -468,11 +480,14 @@ static int encode_to_git(const char *path, const char *src, size_t src_len,
  }
  
  static int encode_to_worktree(const char *path, const char *src, size_t src_len,
@@ -47,7 +58,7 @@ index a8870ba..8e5c6fa 100644
  	/*
  	 * No encoding is specified or there is nothing to encode.
  	 * Tell the caller that the content was not modified.
-@@ -1302,18 +1313,37 @@ static int git_path_check_ident(struct attr_check_item *check)
+@@ -1302,18 +1317,37 @@ static int git_path_check_ident(struct attr_check_item *check)
  
  static struct attr_check *check;
  
@@ -86,7 +97,7 @@ index a8870ba..8e5c6fa 100644
  
  	git_check_attr(istate, path, check);
  	ccheck = check->items;
-@@ -1334,6 +1364,8 @@ void convert_attrs(struct index_state *istate,
+@@ -1334,6 +1368,8 @@ void convert_attrs(struct index_state *istate,
  			ca->crlf_action = CRLF_TEXT_CRLF;
  	}
  	ca->working_tree_encoding = git_path_check_encoding(ccheck + 5);
@@ -95,7 +106,7 @@ index a8870ba..8e5c6fa 100644
  
  	/* Save attr and make a decision for action */
  	ca->attr_action = ca->crlf_action;
-@@ -1427,7 +1459,7 @@ int convert_to_git(struct index_state *istate,
+@@ -1427,7 +1463,7 @@ int convert_to_git(struct index_state *istate,
  		len = dst->len;
  	}
  
@@ -104,7 +115,7 @@ index a8870ba..8e5c6fa 100644
  	if (ret && dst) {
  		src = dst->buf;
  		len = dst->len;
-@@ -1455,7 +1487,7 @@ void convert_to_git_filter_fd(struct index_state *istate,
+@@ -1455,7 +1491,7 @@ void convert_to_git_filter_fd(struct index_state *istate,
  	if (!apply_filter(path, NULL, 0, fd, dst, ca.drv, CAP_CLEAN, NULL, NULL))
  		die(_("%s: clean filter '%s' failed"), path, ca.drv->name);
  
@@ -113,7 +124,7 @@ index a8870ba..8e5c6fa 100644
  	crlf_to_git(istate, path, dst->buf, dst->len, dst, ca.crlf_action, conv_flags);
  	ident_to_git(dst->buf, dst->len, dst, ca.ident);
  }
-@@ -1487,7 +1519,7 @@ static int convert_to_working_tree_ca_internal(const struct conv_attrs *ca,
+@@ -1487,7 +1523,7 @@ static int convert_to_working_tree_ca_internal(const struct conv_attrs *ca,
  		}
  	}
  


### PR DESCRIPTION
Git has a trace_encoding routine that print's trace output when `GIT_TRACE_WORKING_TREE_ENCODING=1` is set. This environment variable is used to debug the encoding contents. 
With a 40mb file that is added, it requests close to 1.8gb of storage from xrealloc which can lead to out of memory errors.
However, the check for GIT_TRACE_WORKING_TREE_ENCODING done after the string is allocated. This adds an early exit to avoid the unnecessary memory allocation.