### PR TITLE
Create a system config to avoid errors with --system

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -111,6 +111,9 @@ zopen_post_install()
   $1/bin/git clone git@github.com:ZOSOpenTools/gitport.git gitport
   set +e
 
+  mkdir -p "$1/etc"
+  touch "$1/etc/gitconfig" # empty it out to avoid error with --system option
+
   # Install a cacert.pem to be used (optionally) by the customer
   if ! $MYDIR/zopen update-cacert -f $1 ; then
     printSoftError "zopen update-cacert failed"
@@ -159,6 +162,7 @@ GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
 GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
 GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
 ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
+GIT_CONFIG_SYSTEM|set|PROJECT_ROOT/etc/gitconfig
 EOF
 }
 


### PR DESCRIPTION
```
git config --system --list
fatal: unable to read config file '/home/itodoro/jenkins/workspace/Port-Build/ibmdir/install/etc/gitconfig': EDC5129I No such file or directory.
```

This file seems to be created manually looking at brew's recipe: https://github.com/Homebrew/homebrew-core/blob/0b95b633f91b9204a513d113e9362cc459ebce59/Formula/g/git.rb#L167-L172