### PR TITLE
External diffs did not tag temporary files with the ccsid from the working tree attribute

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -150,10 +150,10 @@ zopen_post_install()
 zopen_append_to_env()
 {
 cat <<ZZ
-  if [ -n "$GIT_TEMPLATE_DIR" ]; then
+  if [ -n "\$GIT_TEMPLATE_DIR" ]; then
     unset GIT_TEMPLATE_DIR
   fi
-  if [ -n "$GIT_EXEC_PATH" ]; then
+  if [ -n "\$GIT_EXEC_PATH" ]; then
     unset GIT_EXEC_PATH
   fi
 ZZ

--- a/stable-patches/diff.c.patch
+++ b/stable-patches/diff.c.patch
@@ -1,5 +1,5 @@
 diff --git a/diff.c b/diff.c
-index 108c187577..4232fa32b3 100644
+index 108c187577..3412fc392e 100644
 --- a/diff.c
 +++ b/diff.c
 @@ -4106,6 +4106,7 @@ int diff_populate_filespec(struct repository *r,
@@ -10,7 +10,7 @@ index 108c187577..4232fa32b3 100644
  	/*
  	 * demote FAIL to WARN to allow inspecting the situation
  	 * instead of refusing.
-@@ -4178,13 +4179,19 @@ int diff_populate_filespec(struct repository *r,
+@@ -4178,9 +4179,18 @@ int diff_populate_filespec(struct repository *r,
  			s->is_binary = 1;
  			return 0;
  		}
@@ -21,16 +21,15 @@ index 108c187577..4232fa32b3 100644
  		if (fd < 0)
  			goto err_empty;
 +
++#ifdef __MVS__
++    if (!autocvtToASCII)
++      __disableautocvt(fd);
++#endif
++
  		s->data = xmmap(NULL, s->size, PROT_READ, MAP_PRIVATE, fd, 0);
  		close(fd);
  		s->should_munmap = 1;
- 
-+    __disableautocvt(fd);
-+
- 		/*
- 		 * Convert from working tree format to canonical git format
- 		 */
-@@ -4284,6 +4291,10 @@ static void prep_temp_blob(struct index_state *istate,
+@@ -4284,6 +4294,10 @@ static void prep_temp_blob(struct index_state *istate,
  		blob = buf.buf;
  		size = buf.len;
  	}

--- a/stable-patches/diff.c.patch
+++ b/stable-patches/diff.c.patch
@@ -1,8 +1,8 @@
 diff --git a/diff.c b/diff.c
-index 648f671..a988d29 100644
+index 108c187577..4232fa32b3 100644
 --- a/diff.c
 +++ b/diff.c
-@@ -4001,6 +4001,7 @@ int diff_populate_filespec(struct repository *r,
+@@ -4106,6 +4106,7 @@ int diff_populate_filespec(struct repository *r,
  	int check_binary = options ? options->check_binary : 0;
  	int err = 0;
  	int conv_flags = global_conv_flags_eol;
@@ -10,7 +10,7 @@ index 648f671..a988d29 100644
  	/*
  	 * demote FAIL to WARN to allow inspecting the situation
  	 * instead of refusing.
-@@ -4073,9 +4074,17 @@ int diff_populate_filespec(struct repository *r,
+@@ -4178,13 +4179,19 @@ int diff_populate_filespec(struct repository *r,
  			s->is_binary = 1;
  			return 0;
  		}
@@ -21,10 +21,23 @@ index 648f671..a988d29 100644
  		if (fd < 0)
  			goto err_empty;
 +
-+#ifdef __MVS__
-+    if (!autocvtToASCII)
-+      __disableautocvt(fd);
-+#endif
  		s->data = xmmap(NULL, s->size, PROT_READ, MAP_PRIVATE, fd, 0);
  		close(fd);
  		s->should_munmap = 1;
+ 
++    __disableautocvt(fd);
++
+ 		/*
+ 		 * Convert from working tree format to canonical git format
+ 		 */
+@@ -4284,6 +4291,10 @@ static void prep_temp_blob(struct index_state *istate,
+ 		blob = buf.buf;
+ 		size = buf.len;
+ 	}
++  
++#ifdef __MVS__
++  tag_file_as_working_tree_encoding(istate, path, temp->tempfile->fd);
++#endif
+ 	if (write_in_full(temp->tempfile->fd, blob, size) < 0 ||
+ 	    close_tempfile_gently(temp->tempfile))
+ 		die_errno("unable to write temp-file");


### PR DESCRIPTION
* Adds a call to `tag_file_as_working_tree_encoding(istate, path, temp->tempfile->fd);` to resolve it