### PR TITLE
Default CA Cert should not override .gitconfig sslcert

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -163,7 +163,7 @@ zopen_append_to_zoslib_env() {
 cat <<EOF
 GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
 GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
-GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
+ZOPEN_GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
 ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
 GIT_CONFIG_SYSTEM|set|PROJECT_ROOT/etc/gitconfig
 EOF


### PR DESCRIPTION
Git includes its own CA certificate (cacert.pem), and it sets the GIT_SSL_CAINFO environment variable internally to ensure Git uses it. However, this environment variable overrides any settings specified in .gitconfig. 

Therefore, we introduce a different check which does not affect the documented GIT_SSL_CAINFO envar.







