### PR TITLE
Added explicit zoslib linking

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -33,9 +33,9 @@ export ZOPEN_COMP=CLANG
 
 export ZOPEN_EXTRA_CONFIGURE_OPTS="--with-zlib=\${ZLIB_HOME} --with-curl=\${CURL_HOME} --with-openssl=\${OPENSSL_HOME} --with-libpcre2=\${PCRE2_HOME} --with-libiconv-prefix=\${LIBICONV_HOME}"
 
-export ZOPEN_EXTRA_CPPFLAGS="-I\${OPENSSL_HOME}/include -I\${GETTEXT_HOME}/include -I\${ZLIB_HOME}/include -I\${NCURSES_HOME}/include -I\${ZOPEN_ROOT}/patches/include -I\${CURL_HOME}/include -I\${EXPAT_HOME}/include -I\${LIBICONV_HOME}/include"
-export ZOPEN_EXTRA_LDFLAGS="-L\${GETTEXT_HOME}/lib -L\${OPENSSL_HOME}/lib -L\${ZLIB_HOME}/lib -L\${NCURSES_HOME}/lib -L\${CURL_HOME}/lib -L\${EXPAT_HOME}/lib -L\${LIBICONV_HOME}/lib"
-export ZOPEN_EXTRA_LIBS="${ZOPEN_EXTRA_LIBS} -lz -lcurl -lssl -lcrypto"
+export ZOPEN_EXTRA_CPPFLAGS="-I\${OPENSSL_HOME}/include -I\${GETTEXT_HOME}/include -I\${ZLIB_HOME}/include -I\${NCURSES_HOME}/include -I\${ZOPEN_ROOT}/patches/include -I\${CURL_HOME}/include -I\${EXPAT_HOME}/include -I\${LIBICONV_HOME}/include -I\${ZOSLIB_HOME}/include"
+export ZOPEN_EXTRA_LDFLAGS="-L\${GETTEXT_HOME}/lib -L\${OPENSSL_HOME}/lib -L\${ZLIB_HOME}/lib -L\${NCURSES_HOME}/lib -L\${CURL_HOME}/lib -L\${EXPAT_HOME}/lib -L\${LIBICONV_HOME}/lib -L\${ZOSLIB_HOME}/lib"
+export ZOPEN_EXTRA_LIBS="${ZOPEN_EXTRA_LIBS} -lz -lcurl -lssl -lcrypto -lzoslib"
 export ZOPEN_EXTRA_CFLAGS="-mzos-target=zosv2r5 -march=z13"
 export ZOPEN_SYSTEM_PREREQS="zos25"
 export CURL_LDFLAGS="-lcurl"


### PR DESCRIPTION
We were getting following error, when run with `zopen build -v -b release -u -gr -sp --no-set-active --build STABLE`

```
IEW2456E 9207 SYMBOL __mkstemp_ascii UNRESOLVED.  MEMBER COULD NOT BE INCLUDED 
          FROM THE DESIGNATED CALL LIBRARY.                                     
 IEW2456E 9207 SYMBOL strcasestr UNRESOLVED.  MEMBER COULD NOT BE INCLUDED FROM 
          THE DESIGNATED CALL LIBRARY.                                          
 IEW2456E 9207 SYMBOL memmem UNRESOLVED.  MEMBER COULD NOT BE INCLUDED FROM THE 
          DESIGNATED CALL LIBRARY.                                              
 IEW2456E 9207 SYMBOL __sysconf UNRESOLVED.  MEMBER COULD NOT BE INCLUDED FROM  
          THE DESIGNATED CALL LIBRARY.                                          
 IEW2456E 9207 SYMBOL __fopen_ascii UNRESOLVED.  MEMBER COULD NOT BE INCLUDED   
          FROM THE DESIGNATED CALL LIBRARY.                                     
 IEW2456E 9207 SYMBOL __zoslib_malloc UNRESOLVED.  MEMBER COULD NOT BE INCLUDED 
          FROM THE DESIGNATED CALL LIBRARY.                                     
 IEW2456E 9207 SYMBOL __open_ascii UNRESOLVED.  MEMBER COULD NOT BE INCLUDED    
          FROM THE DESIGNATED CALL LIBRARY.                                     
 IEW2456E 9207 SYMBOL __readlink UNRESOLVED.  MEMBER COULD NOT BE INCLUDED FROM 
          THE DESIGNATED CALL LIBRARY.                                          
 IEW2456E 9207 SYMBOL getdelim UNRESOLVED.  MEMBER COULD NOT BE INCLUDED FROM   
          THE DESIGNATED CALL LIBRARY.                                          
 IEW2456E 9207 SYMBOL libintl_ngettext UNRESOLVED.  MEMBER COULD NOT BE INCLUDED
          FROM THE DESIGNATED CALL LIBRARY.                                     
 IEW2456E 9207 SYMBOL libintl_bindtextdomain UNRESOLVED.  MEMBER COULD NOT BE   
          INCLUDED FROM THE DESIGNATED CALL LIBRARY.                            
 IEW2456E 9207 SYMBOL libintl_bind_textdomain_codeset UNRESOLVED.  MEMBER COULD 
          NOT BE INCLUDED FROM THE DESIGNATED CALL LIBRARY.                     
 IEW2456E 9207 SYMBOL libintl_textdomain UNRESOLVED.  MEMBER COULD NOT BE       
          INCLUDED FROM THE DESIGNATED CALL LIBRARY.                            
 IEW2456E 9207 SYMBOL __pipe_ascii UNRESOLVED.  MEMBER COULD NOT BE INCLUDED    
          FROM THE DESIGNATED CALL LIBRARY.                                     
 IEW2456E 9207 SYMBOL __pthread_create_extended UNRESOLVED.  MEMBER COULD NOT BE
          INCLUDED FROM THE DESIGNATED CALL LIBRARY.                            
 IEW2456E 9207 SYMBOL __strerror_ascii UNRESOLVED.  MEMBER COULD NOT BE INCLUDED
          FROM THE DESIGNATED CALL LIBRARY.                                     
 IEW2456E 9207 SYMBOL __close UNRESOLVED.  MEMBER COULD NOT BE INCLUDED FROM THE
          DESIGNATED CALL LIBRARY.                                              
 IEW2456E 9207 SYMBOL __zoslib_free UNRESOLVED.  MEMBER COULD NOT BE INCLUDED   
          FROM THE DESIGNATED CALL LIBRARY.                                     
 IEW2456E 9207 SYMBOL libintl_gettext UNRESOLVED.  MEMBER COULD NOT BE INCLUDED 
          FROM THE DESIGNATED CALL LIBRARY.                                     
 IEW2665S 40FF MODULE *NULL*  IS NON-EXECUTABLE AND WAS NOT SAVED BECAUSE       
          STORENX=NEVER.                                                        
IEW5033 The binder ended with return code 12.
```


