### PR TITLE
Upgrade to Git 2.55.0 and disable Rust for OS/390

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -3,7 +3,7 @@ export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_CATEGORIES="development source_control"
 
 # bump: git-version /GIT_VERSION="(.*)"/ https://github.com/git/git.git|*
-GIT_VERSION="2.54.0"
+GIT_VERSION="2.55.0"
 
 export ZOPEN_DEV_URL="https://github.com/git/git.git"
 export ZOPEN_DEV_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext coreutils diffutils bash tar check_python gawk zusage libpsl libssh2"

--- a/stable-patches/config.mak.uname.patch
+++ b/stable-patches/config.mak.uname.patch
@@ -1,8 +1,8 @@
 diff --git a/config.mak.uname b/config.mak.uname
-index d5112168a4..17716314c0 100644
+index 9ebd240..b8c51ff 100644
 --- a/config.mak.uname
 +++ b/config.mak.uname
-@@ -639,12 +639,19 @@ ifeq ($(uname_S),NONSTOP_KERNEL)
+@@ -678,12 +678,20 @@ ifeq ($(uname_S),NONSTOP_KERNEL)
  	SHELL_PATH = /usr/coreutils/bin/bash
  endif
  ifeq ($(uname_S),OS/390)
@@ -12,6 +12,7 @@ index d5112168a4..17716314c0 100644
 +	SHELL_PATH_FOR_SCRIPTS = /bin/env bash
 +	PYTHON_PATH = python
  	NO_SYS_POLL_H = YesPlease
++	NO_RUST = YesPlease
 +	RUNTIME_PREFIX = YesPlease
  	NO_STRCASESTR = YesPlease
  	NO_REGEX = YesPlease

--- a/stable-patches/environment.c.patch
+++ b/stable-patches/environment.c.patch
@@ -1,8 +1,8 @@
 diff --git a/environment.c b/environment.c
-index 8ffbf92..bef0b5d 100644
+index ba2c601..3682377 100644
 --- a/environment.c
 +++ b/environment.c
-@@ -26,6 +26,7 @@
+@@ -27,6 +27,7 @@
  #include "repository.h"
  #include "config.h"
  #include "refs.h"
@@ -10,9 +10,9 @@ index 8ffbf92..bef0b5d 100644
  #include "fmt-merge-msg.h"
  #include "commit.h"
  #include "strvec.h"
-@@ -57,6 +58,10 @@ char *git_attributes_file;
- int zlib_compression_level = Z_BEST_SPEED;
- int pack_compression_level = Z_DEFAULT_COMPRESSION;
+@@ -52,6 +53,10 @@ char *git_log_output_encoding;
+ char *apply_default_whitespace;
+ char *apply_default_ignorewhitespace;
  int fsync_object_files = -1;
 +#ifdef __MVS__
 +int ignore_file_tags = 0;
@@ -21,21 +21,21 @@ index 8ffbf92..bef0b5d 100644
  int use_fsync = -1;
  enum fsync_method fsync_method = FSYNC_METHOD_DEFAULT;
  enum fsync_component fsync_components = FSYNC_COMPONENTS_DEFAULT;
-@@ -406,6 +411,18 @@ int git_default_core_config(const char *var, const char *value,
+@@ -398,6 +403,18 @@ int git_default_core_config(const char *var, const char *value,
  		return 0;
  	}
  
-+#ifdef __MVS__
-+	if (!strcmp(var, "core.ignorefiletags")) {
++	#ifdef __MVS__
++	       if (!strcmp(var, "core.ignorefiletags")) {
 +		ignore_file_tags = git_config_bool(var, value);
 +		return 0;
-+	}
++	      }
 +
-+	if (!strcmp(var, "core.utf8ccsid")) {
++	       if (!strcmp(var, "core.utf8ccsid")) {
 +		utf8_ccsid = git_config_ulong(var, value, ctx->kvi);
 +		return 0;
-+	}
-+#endif
++	       }
++	#endif
 +
  	if (!strcmp(var, "core.safecrlf")) {
  		int eol_rndtrp_die;

--- a/stable-patches/environment.h.patch
+++ b/stable-patches/environment.h.patch
@@ -1,14 +1,15 @@
 diff --git a/environment.h b/environment.h
-index 27f657a..ae908b6 100644
+index 6f18286..8503f5f 100644
 --- a/environment.h
 +++ b/environment.h
-@@ -159,6 +159,9 @@ extern int zlib_compression_level;
- extern int pack_compression_level;
+@@ -171,6 +171,10 @@ extern char *apply_default_whitespace;
+ extern char *apply_default_ignorewhitespace;
  extern unsigned long pack_size_limit_cfg;
  
 +#ifdef __MVS__
 +extern int utf8_ccsid;
 +#endif
- extern int precomposed_unicode;
++
  extern int protect_hfs;
  extern int protect_ntfs;
+ 


### PR DESCRIPTION
- Bump GIT_VERSION to 2.55.0
- Add NO_RUST = YesPlease to config.mak.uname.patch for OS/390
- Update environment patches for compatibility
- Fixes cargo build error on z/OS systems